### PR TITLE
Fix for check for empty request leading to Default Request

### DIFF
--- a/GSA_Adapter/AdapterActions/Pull.cs
+++ b/GSA_Adapter/AdapterActions/Pull.cs
@@ -32,7 +32,7 @@ namespace BH.Adapter.GSA
         {
             List<object> readresult = new List<object>();
 
-            if (request == null || (request as FilterRequest)?.Type == null)
+            if (request == null || (request is FilterRequest && (request as FilterRequest)?.Type == null))
             {
                 readresult.AddRange(ReadNodes());
                 readresult.AddRange(ReadBars());


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #127 

 <!-- Add short description of what has been fixed -->

Fixing Pull override will always enter default if type is not filterRequest
