### PR TITLE
Updating result extraction to be using result requests

### DIFF
--- a/GSA_Adapter/CRUD/ReadResults.cs
+++ b/GSA_Adapter/CRUD/ReadResults.cs
@@ -120,7 +120,7 @@ namespace BH.Adapter.GSA
                 }
             }
 
-            return loadCases.Where(x => CheckAnalysisCaseExists(x, "A" + x.ToString(), raiseMessages) && CheckAnalysisCaseResultsExists(x, "A" + x, raiseMessages)).ToList();
+            return loadCases.Where(x => CheckAnalysisCaseExists(x, "A" + x.ToString(), raiseMessages) && CheckAnalysisCaseResultsExists(x, "A" + x)).ToList();
         }
 
         /***************************************************/
@@ -209,7 +209,7 @@ namespace BH.Adapter.GSA
             {
                 string descriptionCase = ac;
                 int idCase = System.Convert.ToInt32(Char.IsLetter(ac[0]) ? ac.Trim().Substring(1) : ac.Trim());
-                if (CheckAnalysisCaseExists(idCase, ac, raiseMessages) && (!checkResults || CheckAnalysisCaseResultsExists(idCase, ac, raiseMessages)))
+                if (CheckAnalysisCaseExists(idCase, ac, raiseMessages) && (!checkResults || CheckAnalysisCaseResultsExists(idCase, ac)))
                 {
                     checkedCases.Add(ac);
                 }
@@ -224,7 +224,7 @@ namespace BH.Adapter.GSA
             if (m_gsaCom.CaseExist(caseDescription[0].ToString(), caseId) != 1)
             {
                 if(raiseError)
-                    Engine.Reflection.Compute.RecordError("Error, analysis case " + caseDescription + " does not exist.");
+                    Engine.Reflection.Compute.RecordError("Analysis case " + caseDescription + " does not exist.");
                 return false;
             }
 
@@ -234,14 +234,12 @@ namespace BH.Adapter.GSA
 
         /***************************************************/
 
-        private bool CheckAnalysisCaseResultsExists(int caseId, string caseDescription, bool raiseWarning = true)
+        private bool CheckAnalysisCaseResultsExists(int caseId, string caseDescription)
         {
 
             if (m_gsaCom.CaseResultsExist(caseDescription[0].ToString(), caseId, 0) != 1)
             {
-                if(raiseWarning)
-                    Engine.Reflection.Compute.RecordWarning("Error, analysis case " + caseDescription + " has no results.");
-
+                Engine.Reflection.Compute.RecordWarning("Analysis case " + caseDescription + " has no results.");
                 return false;
             }
 

--- a/GSA_Adapter/CRUD/ReadResults.cs
+++ b/GSA_Adapter/CRUD/ReadResults.cs
@@ -43,14 +43,12 @@ namespace BH.Adapter.GSA
 
         protected override IEnumerable<IResult> ReadResults(Type type, IList ids = null, IList cases = null, int divisions = 5)
         {
-            IResultRequest request = Engine.Structure.Compute.GenerateResultRequest(type, ids, cases, divisions);
+            IResultRequest request = Engine.Structure.Create.IResultRequest(type, ids?.Cast<object>(), cases?.Cast<object>(), divisions);
 
             if (request != null)
                 return this.ReadResults(request as dynamic);
             else
                 return new List<IResult>();
-
-
         }
 
  

--- a/GSA_Adapter/CRUD/ReadResults.cs
+++ b/GSA_Adapter/CRUD/ReadResults.cs
@@ -60,8 +60,10 @@ namespace BH.Adapter.GSA
         private List<int> CheckAndGetAnalysisCaseNumbers(IList cases)
         {
             List<int> loadCases;
+            bool raiseMessages = true;
             if (cases == null || cases.Count == 0)
             {
+                raiseMessages = false;
                 loadCases = new List<int>();
                 string sResult;
                 int maxIndex = m_gsaCom.GwaCommand("HIGHEST, ANAL");
@@ -77,7 +79,7 @@ namespace BH.Adapter.GSA
                     }
                     catch
                     {
-                        Engine.Reflection.Compute.RecordError("Analysis task " + i + "could not be found in the model.");
+                        //Engine.Reflection.Compute.RecordError("Analysis task " + i + "could not be found in the model.");
                     }
                 }
 
@@ -118,7 +120,7 @@ namespace BH.Adapter.GSA
                 }
             }
 
-            return loadCases.Where(x => CheckAnalysisCaseExists(x, "A" + x.ToString()) && CheckAnalysisCaseResultsExists(x, "A"+x)).ToList();
+            return loadCases.Where(x => CheckAnalysisCaseExists(x, "A" + x.ToString(), raiseMessages) && CheckAnalysisCaseResultsExists(x, "A" + x, raiseMessages)).ToList();
         }
 
         /***************************************************/
@@ -133,8 +135,11 @@ namespace BH.Adapter.GSA
         private List<string> CheckAndGetAnalysisCases(IList cases)
         {
             List<string> loadCases;
+            bool raiseMessages = true;
+
             if (cases == null || cases.Count == 0)
             {
+                raiseMessages = false;  //Do not rasie messages for cases if all are being pulled.
                 loadCases = new List<string>();
                 string sResult;
                 int maxIndex = m_gsaCom.GwaCommand("HIGHEST, ANAL");
@@ -190,23 +195,21 @@ namespace BH.Adapter.GSA
                     {
                         loadCases.Add("A" + (o as oM.Structure.Loads.LoadCombination).Number);
                     }
-
                 }
-                return loadCases;
             }
 
-            return CheckAnalysisCasesExist(loadCases);
+            return CheckAnalysisCasesExist(loadCases, true, raiseMessages);
         }
 
         /***************************************************/
-        private List<string> CheckAnalysisCasesExist(List<string> cases, bool checkResults = true)
+        private List<string> CheckAnalysisCasesExist(List<string> cases, bool checkResults = true, bool raiseMessages = true)
         {
             List<string> checkedCases = new List<string>();
             foreach (string ac in cases)
             {
                 string descriptionCase = ac;
                 int idCase = System.Convert.ToInt32(Char.IsLetter(ac[0]) ? ac.Trim().Substring(1) : ac.Trim());
-                if (CheckAnalysisCaseExists(idCase, ac) && (!checkResults || CheckAnalysisCaseResultsExists(idCase, ac)))
+                if (CheckAnalysisCaseExists(idCase, ac, raiseMessages) && (!checkResults || CheckAnalysisCaseResultsExists(idCase, ac, raiseMessages)))
                 {
                     checkedCases.Add(ac);
                 }
@@ -215,12 +218,13 @@ namespace BH.Adapter.GSA
         }
 
         /***************************************************/
-        private bool CheckAnalysisCaseExists(int caseId, string caseDescription)
+        private bool CheckAnalysisCaseExists(int caseId, string caseDescription, bool raiseError = true)
         {
 
             if (m_gsaCom.CaseExist(caseDescription[0].ToString(), caseId) != 1)
             {
-                Engine.Reflection.Compute.RecordError("Error, analysis case " + caseDescription + " does not exist.");
+                if(raiseError)
+                    Engine.Reflection.Compute.RecordError("Error, analysis case " + caseDescription + " does not exist.");
                 return false;
             }
 
@@ -230,12 +234,14 @@ namespace BH.Adapter.GSA
 
         /***************************************************/
 
-        private bool CheckAnalysisCaseResultsExists(int caseId, string caseDescription)
+        private bool CheckAnalysisCaseResultsExists(int caseId, string caseDescription, bool raiseWarning = true)
         {
 
             if (m_gsaCom.CaseResultsExist(caseDescription[0].ToString(), caseId, 0) != 1)
             {
-                Engine.Reflection.Compute.RecordError("Error, analysis case " + caseDescription + " has no results.");
+                if(raiseWarning)
+                    Engine.Reflection.Compute.RecordWarning("Error, analysis case " + caseDescription + " has no results.");
+
                 return false;
             }
 

--- a/GSA_Adapter/CRUD/ReadResults.cs
+++ b/GSA_Adapter/CRUD/ReadResults.cs
@@ -24,7 +24,7 @@ using BH.Engine.GSA;
 using BH.oM.Base;
 using BH.oM.Common;
 using BH.oM.Structure.Elements;
-using BH.oM.Structure.Results;
+using BH.oM.Structure.Requests;
 using BH.oM.Data.Requests;
 using Interop.gsa_8_7;
 using System;
@@ -51,12 +51,21 @@ namespace BH.Adapter.GSA
                 return new List<IResult>();
         }
 
- 
+
 
         /***************************************************/
         /**** Private  Methods - Index checking         ****/
         /***************************************************/
-        
+
+        private void CheckModes(IStructuralResultRequest request)
+        {
+            //TODO: Handle mode selection
+
+            if (request.Modes != null && request.Modes.Count > 0)
+                Engine.Reflection.Compute.RecordWarning("Mode selection is not yet implemented in the GSA_Adapter.");
+        }
+
+
         private List<int> CheckAndGetAnalysisCaseNumbers(IList cases)
         {
             List<int> loadCases;

--- a/GSA_Adapter/CRUD/ReadResults.cs
+++ b/GSA_Adapter/CRUD/ReadResults.cs
@@ -71,64 +71,6 @@ namespace BH.Adapter.GSA
 
         }
 
-        /***************************************************/
-
-        private IEnumerable<IResult> ExtractGlobalReaction(List<int> cases)
-        {
-            List<GlobalReactions> reactions = new List<GlobalReactions>();
-
-            string id = ""; //TODO: Strategy for ids for full model
-
-            foreach (int loadCase in cases)
-            {
-                List<string> forceStrings = new List<string>();
-                List<string> momentStrings = new List<string>();
-
-                forceStrings.Add(m_gsaCom.GwaCommand("GET, TOTAL_FORCE, " + loadCase + ",REACT"));
-                forceStrings.Add(m_gsaCom.GwaCommand("GET, TOTAL_FORCE, " + loadCase + ",SUPPORT"));
-                forceStrings.Add(m_gsaCom.GwaCommand("GET, TOTAL_FORCE, " + loadCase + ",SPRING"));
-                forceStrings.Add(m_gsaCom.GwaCommand("GET, TOTAL_FORCE, " + loadCase + ",SOIL"));
-
-                momentStrings.Add(m_gsaCom.GwaCommand("GET, TOTAL_MOMENT, " + loadCase + ",REACT"));
-                momentStrings.Add(m_gsaCom.GwaCommand("GET, TOTAL_MOMENT, " + loadCase + ",SUPPORT"));
-                momentStrings.Add(m_gsaCom.GwaCommand("GET, TOTAL_MOMENT, " + loadCase + ",SPRING"));
-                momentStrings.Add(m_gsaCom.GwaCommand("GET, TOTAL_MOMENT, " + loadCase + ",SOIL"));
-
-                //string force = m_gsaCom.GwaCommand("GET, TOTAL_FORCE, " + loadCase + ",REACT");
-                //string moment = m_gsaCom.GwaCommand("GET, TOTAL_MOMENT, " + loadCase + ",REACT");
-                //reactions.Add(BH.Engine.GSA.Convert.ToBHoMGlobalReactions(id, force, moment));
-
-                reactions.Add(BH.Engine.GSA.Convert.ToBHoMGlobalReactions(id, forceStrings, momentStrings));
-            }
-
-            return reactions;
-        }
-
-        /***************************************************/
-
-        private IEnumerable<IResult> ExtractGlobalDynamics(List<int> cases)
-        {
-            List<ModalDynamics> dynamics = new List<ModalDynamics>();
-
-            string id = ""; //TODO: Strategy for ids for full model
-
-            foreach (int loadCase in cases)
-            {
-                string mode = m_gsaCom.GwaCommand("GET, MODE, " + loadCase);
-
-                if (String.IsNullOrWhiteSpace(mode))
-                    continue;
-                string frequency = m_gsaCom.GwaCommand("GET, FREQ, " + loadCase);
-                string mass = m_gsaCom.GwaCommand("GET, MASS, " + loadCase);
-                string damping = m_gsaCom.GwaCommand("GET, MODAL_DAMP, " + loadCase);
-                string stiffness = m_gsaCom.GwaCommand("GET, MODAL_STIFF, " + loadCase);
-                string effMassTran = m_gsaCom.GwaCommand("GET, EFF_MASS, " + loadCase + ",TRAN");
-                string effMassRot = m_gsaCom.GwaCommand("GET, EFF_MASS, " + loadCase + ",ROT");
-                dynamics.Add(BH.Engine.GSA.Convert.ToBHoMModalDynamics(id, mode, frequency, mass, stiffness, damping, effMassTran, effMassRot));
-            }
-
-            return dynamics;
-        }
 
         /***************************************************/
         /**** Object Results  Methods                   ****/

--- a/GSA_Adapter/CRUD/ReadResultsElements.cs
+++ b/GSA_Adapter/CRUD/ReadResultsElements.cs
@@ -44,10 +44,11 @@ namespace BH.Adapter.GSA
         /**** Public method - Read override             ****/
         /***************************************************/
 
-        public IEnumerable<IResult> ReadResults(IResultRequest request)
+        public IEnumerable<IResult> ReadResults(IStructuralResultRequest request)
         {
             List<int> objectIds = CheckAndGetIds(request);
             List<string> loadCases = CheckAndGetAnalysisCases(request);
+            CheckModes(request);
 
             ResHeader header;
             ForceConverter converter;

--- a/GSA_Adapter/CRUD/ReadResultsElements.cs
+++ b/GSA_Adapter/CRUD/ReadResultsElements.cs
@@ -58,6 +58,8 @@ namespace BH.Adapter.GSA
             if (!IGetExtractionParameters(request, out header, out converter, out axis, out unitFactor, out divisions, out flags))
                 return new List<IResult>();
 
+            flags += (int)Output_Init_Flags.OP_INIT_INFINITY;
+
             List<IResult> results = new List<IResult>();
             int midPoints = divisions == 1 ? divisions : divisions - 2;
             foreach (string loadCase in loadCases)

--- a/GSA_Adapter/CRUD/ReadResultsElements.cs
+++ b/GSA_Adapter/CRUD/ReadResultsElements.cs
@@ -1,0 +1,305 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.GSA;
+using BH.oM.Base;
+using BH.oM.Common;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.Requests;
+using BH.oM.Data.Requests;
+using BH.oM.Structure.Results;
+using Interop.gsa_8_7;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Adapter.GSA
+{
+    public partial class GSAAdapter
+    {
+
+        /***************************************************/
+        /**** Public method - Read override             ****/
+        /***************************************************/
+
+        public IEnumerable<IResult> ReadResults(IResultRequest request)
+        {
+            List<int> objectIds = CheckAndGetIds(request);
+            List<string> loadCases = CheckAndGetAnalysisCases(request.Cases);
+
+            ResHeader header;// = type.ResultHeader();
+            ForceConverter converter;
+            string axis;
+            double unitFactor;
+            int divisions;
+            int flags;
+            if (!IGetExtractionParameters(request, out header, out converter, out axis, out unitFactor, out divisions, out flags))
+                return new List<IResult>();
+
+            List<IResult> results = new List<IResult>();
+            int midPoints = divisions == 1 ? divisions : divisions - 2;
+            foreach (string loadCase in loadCases)
+            {
+                if (InitializeLoadextraction(header, loadCase, midPoints, axis, flags))
+                {
+                    foreach (int id in objectIds)
+                    {
+                        GsaResults[] gsaResults = GetResults(id, unitFactor);
+                        if (gsaResults != null)
+                        {
+                            foreach (GsaResults gsaRes in gsaResults)
+                            {
+                                results.Add(converter.Invoke(gsaRes, id.ToString(), loadCase, gsaResults.Length));
+                            }
+
+                            if(gsaResults.Length != divisions)
+                                Engine.Reflection.Compute.RecordWarning("Different number of results compared to the expected for object with id " + id + ", for loadcase: " + loadCase);
+
+                        }
+                        else
+                        {
+                            Engine.Reflection.Compute.RecordError("Unable to extract results for object with id " + id + ", for loadcase: " + loadCase);
+                        }
+                    }
+                }
+            }
+
+            return results;
+        }
+
+
+        /***************************************************/
+
+        private bool GetExtractionParameters(BarResultRequest request, out ResHeader header, out ForceConverter converter, out string axis, out double unitFactor, out int divisions, out int flags)
+        {
+            axis = BH.Engine.GSA.Output_Axis.Local();
+            divisions = request.Divisions;
+
+            double[] unitFactors = GetUnitFactors();
+
+            switch (request.DivisionType)
+            {
+                case DivisionType.ExtremeValues:
+                    flags = (int)Output_Init_Flags.OP_INIT_1D_AUTO_PTS;
+                    break;
+                case DivisionType.EvenlyDistributed:
+                default:
+                    flags = 0;
+                    break;
+            }
+
+            switch (request.ResultType)
+            {
+                case BarResultType.BarForce:
+                    converter = BH.Engine.GSA.Convert.ToBHoMBarForce;
+                    header = ResHeader.REF_FORCE_EL1D;
+                    unitFactor = unitFactors[(int)BH.Engine.GSA.UnitType.FORCE];
+                    break;
+                case BarResultType.BarDeformation:
+                    converter = BH.Engine.GSA.Convert.ToBHoMBarDeformation;
+                    header = ResHeader.REF_DISP_EL1D;
+                    unitFactor = unitFactors[(int)BH.Engine.GSA.UnitType.LENGTH];
+                    break;
+                case BarResultType.BarStress:
+                    converter = BH.Engine.GSA.Convert.ToBHoMBarStress;
+                    header = ResHeader.REF_STRESS_EL1D;
+                    unitFactor = unitFactors[(int)BH.Engine.GSA.UnitType.STRESS];
+                    break;
+                case BarResultType.BarStrain:
+                    converter = BH.Engine.GSA.Convert.ToBHoMBarStrain;
+                    header = ResHeader.REF_STRAIN_EL1D;
+                    unitFactor = 1;
+                    break;
+                default:
+                    converter = null;
+                    header = ResHeader.REF_ACC;
+                    unitFactor = 1;
+                    Engine.Reflection.Compute.RecordError("Result of type " + request.ResultType + " is not yet supported");
+                    return false;
+            }
+
+            return true;
+        }
+
+        /***************************************************/
+
+        private bool GetExtractionParameters(NodeResultRequest request, out ResHeader header, out ForceConverter converter, out string axis, out double unitFactor, out int divisions, out int flags)
+        {
+
+            switch (request.Axis)
+            {
+                case oM.Structure.Loads.LoadAxis.Local:
+                    axis = BH.Engine.GSA.Output_Axis.Local();
+                    break;
+                case oM.Structure.Loads.LoadAxis.Global:
+                default:
+                    axis = BH.Engine.GSA.Output_Axis.Global();
+                    break;
+            }
+
+            divisions = 1;
+            double[] unitFactors = GetUnitFactors();
+
+            flags = 0;
+
+            switch (request.ResultType)
+            {
+                case NodeResultType.NodeReaction:
+                    header = ResHeader.REF_REAC;
+                    converter = BH.Engine.GSA.Convert.ToBHoMReaction;
+                    unitFactor = unitFactors[(int)BH.Engine.GSA.UnitType.FORCE];
+                    break;
+                case NodeResultType.NodeDisplacement:
+                    converter = BH.Engine.GSA.Convert.ToBHoMNodeDisplacement;
+                    header = ResHeader.REF_DISP;
+                    unitFactor = unitFactors[(int)BH.Engine.GSA.UnitType.LENGTH];
+                    break;
+                case NodeResultType.NodeVelocity:
+                case NodeResultType.NodeAcceleration:
+                default:
+                    converter = null;
+                    header = ResHeader.REF_ACC;
+                    unitFactor = 1;
+                    Engine.Reflection.Compute.RecordError("Result of type " + request.ResultType + " is not yet supported");
+                    return false;
+            }
+
+            return true;
+        }
+
+        /***************************************************/
+
+        private bool IGetExtractionParameters(IResultRequest request, out ResHeader header, out ForceConverter converter, out string axis, out double unitFactor, out int divisions, out int flags)
+        {
+            return GetExtractionParameters(request as dynamic, out header, out converter, out axis, out unitFactor, out divisions, out flags);
+        }
+
+        /***************************************************/
+
+        private bool GetExtractionParameters(IResultRequest request, out ResHeader header, out ForceConverter converter, out string axis, out double unitFactor, out int divisions, out int flags)
+        {
+            axis = null;
+            Engine.Reflection.Compute.RecordError("Request of type " + request.GetType().ToString() + " is not supported");
+            header = ResHeader.REF_ACC;
+            converter = null;
+            unitFactor = 1;
+            flags = 0;
+            divisions = 0;
+            return false;
+        }
+
+        /***************************************************/
+        /**** Private  Methods - Result extraction      ****/
+        /***************************************************/
+
+        private bool InitializeLoadextraction(ResHeader header, string loadCase, int divisions, string axis, int flags)
+        {
+            if (m_gsaCom.Output_Init_Arr(flags, axis, loadCase, header, divisions) != 0)
+            {
+                Engine.Reflection.Compute.RecordError("Failed to initialize result extraction for loadcase: " + loadCase);
+                return false;
+            }
+            return true;
+        }
+
+
+        /***************************************************/
+        /**** Private  Methods - Index checking         ****/
+        /***************************************************/
+
+        private List<int> CheckAndGetIds(IResultRequest request)
+        {
+            IList ids = request.ObjectIds;
+            if (ids == null || ids.Count == 0)
+            {
+                return GetAllIds(request as dynamic);
+            }
+            else if (ids is List<string>)
+                return (ids as List<string>).Select(x => int.Parse(x)).ToList();
+            else if (ids is List<int>)
+                return ids as List<int>;
+            else if (ids is List<double>)
+                return (ids as List<double>).Select(x => (int)Math.Round(x)).ToList();
+            else
+            {
+                List<int> idsOut = new List<int>();
+                foreach (object o in ids)
+                {
+                    int id;
+                    object idObj;
+                    if (int.TryParse(o.ToString(), out id))
+                    {
+                        idsOut.Add(id);
+                    }
+                    else if (o is IBHoMObject && (o as IBHoMObject).CustomData.TryGetValue(AdapterId, out idObj) && int.TryParse(idObj.ToString(), out id))
+                        idsOut.Add(id);
+                }
+                return idsOut;
+            }
+
+        }
+
+        /***************************************************/
+
+        private List<int> GetAllIds(BarResultRequest request)
+        {
+            List<int> ids = new List<int>();
+            int maxIndex = m_gsaCom.GwaCommand("HIGHEST, EL");
+            GsaElement[] gsaElems;
+            m_gsaCom.Elements(CreateIntSequence(maxIndex), out gsaElems);
+
+            foreach (GsaElement elem in gsaElems)
+            {
+                int gsaType = elem.eType;
+
+                //Check that the element type is a bar
+                if (gsaType == 1 || gsaType == 2 || gsaType == 20 || gsaType == 21)
+                    ids.Add(elem.Ref);
+
+            }
+
+            return ids;
+        }
+
+        /***************************************************/
+
+        private List<int> GetAllIds(NodeResultRequest request)
+        {
+            int highestIndex = m_gsaCom.GwaCommand("HIGHEST, NODE");
+
+            GsaNode[] nodes;
+            m_gsaCom.Nodes(CreateIntSequence(highestIndex), out nodes);
+
+            return nodes.Select(x => x.Ref).ToList();
+        }
+
+        /***************************************************/
+
+        private List<int> GetAllIds(IResultRequest request)
+        {
+            return new List<int>();
+        }
+
+        /***************************************************/
+    }
+}

--- a/GSA_Adapter/CRUD/ReadResultsElements.cs
+++ b/GSA_Adapter/CRUD/ReadResultsElements.cs
@@ -60,6 +60,8 @@ namespace BH.Adapter.GSA
 
             flags += (int)Output_Init_Flags.OP_INIT_INFINITY;
 
+            bool raiseDivisionsWarning = (request is BarResultRequest) && ((request as BarResultRequest).DivisionType == DivisionType.EvenlyDistributed);
+
             List<IResult> results = new List<IResult>();
             int midPoints = divisions == 1 ? divisions : divisions - 2;
             foreach (string loadCase in loadCases)
@@ -76,7 +78,7 @@ namespace BH.Adapter.GSA
                                 results.Add(converter.Invoke(gsaRes, id.ToString(), loadCase, gsaResults.Length));
                             }
 
-                            if(gsaResults.Length != divisions)
+                            if(raiseDivisionsWarning && gsaResults.Length != divisions)
                                 Engine.Reflection.Compute.RecordWarning("Different number of results compared to the expected for object with id " + id + ", for loadcase: " + loadCase);
 
                         }

--- a/GSA_Adapter/CRUD/ReadResultsElements.cs
+++ b/GSA_Adapter/CRUD/ReadResultsElements.cs
@@ -91,6 +91,7 @@ namespace BH.Adapter.GSA
                 }
             }
 
+            results.Sort();
             return results;
         }
 

--- a/GSA_Adapter/CRUD/ReadResultsElements.cs
+++ b/GSA_Adapter/CRUD/ReadResultsElements.cs
@@ -49,7 +49,7 @@ namespace BH.Adapter.GSA
             List<int> objectIds = CheckAndGetIds(request);
             List<string> loadCases = CheckAndGetAnalysisCases(request);
 
-            ResHeader header;// = type.ResultHeader();
+            ResHeader header;
             ForceConverter converter;
             string axis;
             double unitFactor;

--- a/GSA_Adapter/CRUD/ReadResultsElements.cs
+++ b/GSA_Adapter/CRUD/ReadResultsElements.cs
@@ -117,11 +117,18 @@ namespace BH.Adapter.GSA
                     header = ResHeader.REF_FORCE_EL1D;
                     unitFactor = unitFactors[(int)BH.Engine.GSA.UnitType.FORCE];
                     break;
-                case BarResultType.BarDeformation:
-                    converter = BH.Engine.GSA.Convert.ToBHoMBarDeformation;
+                case BarResultType.BarDisplacement:
+                    axis = BH.Engine.GSA.Output_Axis.Global();
+                    converter = BH.Engine.GSA.Convert.ToBHoMBarDisplacement;
                     header = ResHeader.REF_DISP_EL1D;
                     unitFactor = unitFactors[(int)BH.Engine.GSA.UnitType.LENGTH];
                     break;
+                case BarResultType.BarDeformation:
+                    converter = null;
+                    header = ResHeader.REF_ACC;
+                    unitFactor = 1;
+                    Engine.Reflection.Compute.RecordError("Extraction of Localised BarDeformations is not supported in GSA. To get full displacements of the Bar in global coordinates, try pulling BarDisplacements");
+                    return false;
                 case BarResultType.BarStress:
                     converter = BH.Engine.GSA.Convert.ToBHoMBarStress;
                     header = ResHeader.REF_STRESS_EL1D;

--- a/GSA_Adapter/CRUD/ReadResultsGlobal.cs
+++ b/GSA_Adapter/CRUD/ReadResultsGlobal.cs
@@ -45,7 +45,8 @@ namespace BH.Adapter.GSA
         public IEnumerable<IResult> ReadResults(GlobalResultRequest request)
         {
             List<int> caseNumbers = CheckAndGetAnalysisCaseNumbers(request.Cases);
-            
+            CheckModes(request);
+
             switch (request.ResultType)
             {
                 case GlobalResultType.Reactions:

--- a/GSA_Adapter/CRUD/ReadResultsGlobal.cs
+++ b/GSA_Adapter/CRUD/ReadResultsGlobal.cs
@@ -1,0 +1,122 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using BH.Engine.GSA;
+using BH.oM.Base;
+using BH.oM.Common;
+using BH.oM.Structure.Elements;
+using BH.oM.Structure.Requests;
+using BH.oM.Data.Requests;
+using BH.oM.Structure.Results;
+using Interop.gsa_8_7;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace BH.Adapter.GSA
+{
+    public partial class GSAAdapter
+    {
+
+        /***************************************************/
+        /**** Public method - Read override             ****/
+        /***************************************************/
+
+        public IEnumerable<IResult> ReadResults(GlobalResultRequest request)
+        {
+            List<int> caseNumbers = CheckAndGetAnalysisCaseNumbers(request.Cases);
+            
+            switch (request.ResultType)
+            {
+                case GlobalResultType.Reactions:
+                    return ExtractGlobalReaction(caseNumbers);
+                case GlobalResultType.ModalDynamics:
+                    return ExtractGlobalDynamics(caseNumbers);
+                default:
+                    Engine.Reflection.Compute.RecordError("Result of type " + request.ResultType + " is not yet supported");
+                    return new List<IResult>();
+            }
+        }
+
+        /***************************************************/
+
+        private IEnumerable<IResult> ExtractGlobalDynamics(List<int> cases)
+        {
+            List<ModalDynamics> dynamics = new List<ModalDynamics>();
+
+            string id = ""; //TODO: Strategy for ids for full model
+
+            foreach (int loadCase in cases)
+            {
+                string mode = m_gsaCom.GwaCommand("GET, MODE, " + loadCase);
+
+                if (String.IsNullOrWhiteSpace(mode))
+                    continue;
+                string frequency = m_gsaCom.GwaCommand("GET, FREQ, " + loadCase);
+                string mass = m_gsaCom.GwaCommand("GET, MASS, " + loadCase);
+                string damping = m_gsaCom.GwaCommand("GET, MODAL_DAMP, " + loadCase);
+                string stiffness = m_gsaCom.GwaCommand("GET, MODAL_STIFF, " + loadCase);
+                string effMassTran = m_gsaCom.GwaCommand("GET, EFF_MASS, " + loadCase + ",TRAN");
+                string effMassRot = m_gsaCom.GwaCommand("GET, EFF_MASS, " + loadCase + ",ROT");
+                dynamics.Add(BH.Engine.GSA.Convert.ToBHoMModalDynamics(id, mode, frequency, mass, stiffness, damping, effMassTran, effMassRot));
+            }
+
+            return dynamics;
+        }
+
+        /***************************************************/
+
+        private IEnumerable<IResult> ExtractGlobalReaction(List<int> cases)
+        {
+            List<GlobalReactions> reactions = new List<GlobalReactions>();
+
+            string id = ""; //TODO: Strategy for ids for full model
+
+            foreach (int loadCase in cases)
+            {
+                List<string> forceStrings = new List<string>();
+                List<string> momentStrings = new List<string>();
+
+                forceStrings.Add(m_gsaCom.GwaCommand("GET, TOTAL_FORCE, " + loadCase + ",REACT"));
+                forceStrings.Add(m_gsaCom.GwaCommand("GET, TOTAL_FORCE, " + loadCase + ",SUPPORT"));
+                forceStrings.Add(m_gsaCom.GwaCommand("GET, TOTAL_FORCE, " + loadCase + ",SPRING"));
+                forceStrings.Add(m_gsaCom.GwaCommand("GET, TOTAL_FORCE, " + loadCase + ",SOIL"));
+
+                momentStrings.Add(m_gsaCom.GwaCommand("GET, TOTAL_MOMENT, " + loadCase + ",REACT"));
+                momentStrings.Add(m_gsaCom.GwaCommand("GET, TOTAL_MOMENT, " + loadCase + ",SUPPORT"));
+                momentStrings.Add(m_gsaCom.GwaCommand("GET, TOTAL_MOMENT, " + loadCase + ",SPRING"));
+                momentStrings.Add(m_gsaCom.GwaCommand("GET, TOTAL_MOMENT, " + loadCase + ",SOIL"));
+
+                //string force = m_gsaCom.GwaCommand("GET, TOTAL_FORCE, " + loadCase + ",REACT");
+                //string moment = m_gsaCom.GwaCommand("GET, TOTAL_MOMENT, " + loadCase + ",REACT");
+                //reactions.Add(BH.Engine.GSA.Convert.ToBHoMGlobalReactions(id, force, moment));
+
+                reactions.Add(BH.Engine.GSA.Convert.ToBHoMGlobalReactions(id, forceStrings, momentStrings));
+            }
+
+            return reactions;
+        }
+
+        /***************************************************/
+    }
+}

--- a/GSA_Adapter/CRUD/ReadResultsGlobal.cs
+++ b/GSA_Adapter/CRUD/ReadResultsGlobal.cs
@@ -47,16 +47,23 @@ namespace BH.Adapter.GSA
             List<int> caseNumbers = CheckAndGetAnalysisCaseNumbers(request.Cases);
             CheckModes(request);
 
+            List<IResult> results;
+
             switch (request.ResultType)
             {
                 case GlobalResultType.Reactions:
-                    return ExtractGlobalReaction(caseNumbers);
+                    results = ExtractGlobalReaction(caseNumbers).ToList();
+                    break;
                 case GlobalResultType.ModalDynamics:
-                    return ExtractGlobalDynamics(caseNumbers);
+                    results = ExtractGlobalDynamics(caseNumbers).ToList();
+                    break;
                 default:
                     Engine.Reflection.Compute.RecordError("Result of type " + request.ResultType + " is not yet supported");
-                    return new List<IResult>();
+                    results = new List<IResult>();
+                    break;
             }
+            results.Sort();
+            return results;
         }
 
         /***************************************************/

--- a/GSA_Adapter/GSA_Adapter.csproj
+++ b/GSA_Adapter/GSA_Adapter.csproj
@@ -102,6 +102,7 @@
     <Compile Include="AdapterActions\Pull.cs" />
     <Compile Include="AdapterActions\Execute.cs" />
     <Compile Include="CRUD\ReadResults.cs" />
+    <Compile Include="CRUD\ReadResultsElements.cs" />
     <Compile Include="CRUD\UpdateObjects.cs" />
     <Compile Include="CRUD\UpdateProperty.cs" />
     <Compile Include="Types\DependencyTypes.cs" />

--- a/GSA_Adapter/GSA_Adapter.csproj
+++ b/GSA_Adapter/GSA_Adapter.csproj
@@ -103,6 +103,7 @@
     <Compile Include="AdapterActions\Execute.cs" />
     <Compile Include="CRUD\ReadResults.cs" />
     <Compile Include="CRUD\ReadResultsElements.cs" />
+    <Compile Include="CRUD\ReadResultsGlobal.cs" />
     <Compile Include="CRUD\UpdateObjects.cs" />
     <Compile Include="CRUD\UpdateProperty.cs" />
     <Compile Include="Types\DependencyTypes.cs" />

--- a/GSA_Engine/Convert/Private Helpers/GsaEnums.cs
+++ b/GSA_Engine/Convert/Private Helpers/GsaEnums.cs
@@ -23,190 +23,191 @@
 namespace BH.Engine.GSA
 {
 
-        /***************************************/
+    /***************************************/
 
-        public enum Out_0D_Results
-        {
-            REF_DISP = 12001000,
-            REF_DISP_DX,
-            REF_DISP_DY,
-            REF_DISP_DZ,
-            REF_DISP_TRANS,
-            REF_DISP_RXX,
-            REF_DISP_RYY,
-            REF_DISP_RZZ,
-            REF_DISP_ROT,
-            REF_DISP_DXY,
+    public enum Out_0D_Results
+    {
+        REF_DISP = 12001000,
+        REF_DISP_DX,
+        REF_DISP_DY,
+        REF_DISP_DZ,
+        REF_DISP_TRANS,
+        REF_DISP_RXX,
+        REF_DISP_RYY,
+        REF_DISP_RZZ,
+        REF_DISP_ROT,
+        REF_DISP_DXY,
 
-            REF_REAC = 12004000,
-            REF_REAC_FX,
-            REF_REAC_FY,
-            REF_REAC_FZ,
-            REF_REAC_FRC,
-            REF_REAC_MXX,
-            REF_REAC_MYY,
-            REF_REAC_MZZ,
-            REF_REAC_MOM,
-        }
+        REF_REAC = 12004000,
+        REF_REAC_FX,
+        REF_REAC_FY,
+        REF_REAC_FZ,
+        REF_REAC_FRC,
+        REF_REAC_MXX,
+        REF_REAC_MYY,
+        REF_REAC_MZZ,
+        REF_REAC_MOM,
+    }
 
-        /***************************************/
+    /***************************************/
 
-        /// <summary>
-        /// 
-        /// </summary>
-        public enum Out_1D_Results
-        {
-            REF_DISP_EL1D = 14001000,
-            REF_DISP_EL1D_DX,
-            REF_DISP_EL1D_DY,
-            REF_DISP_EL1D_DZ,
-            REF_DISP_EL1D_TRANS,
-            REF_DISP_EL1D_RXX,
-            REF_DISP_EL1D_RYY,
-            REF_DISP_EL1D_RZZ,
-            REF_DISP_EL1D_ROT,
+    /// <summary>
+    /// 
+    /// </summary>
+    public enum Out_1D_Results
+    {
+        REF_DISP_EL1D = 14001000,
+        REF_DISP_EL1D_DX,
+        REF_DISP_EL1D_DY,
+        REF_DISP_EL1D_DZ,
+        REF_DISP_EL1D_TRANS,
+        REF_DISP_EL1D_RXX,
+        REF_DISP_EL1D_RYY,
+        REF_DISP_EL1D_RZZ,
+        REF_DISP_EL1D_ROT,
 
-            REF_FORCE_EL1D = 14002000,
-            REF_FORCE_EL1D_FX,
-            REF_FORCE_EL1D_FY,
-            REF_FORCE_EL1D_FZ,
-            REF_FORCE_EL1D_FRC,
-            REF_FORCE_EL1D_MXX,
-            REF_FORCE_EL1D_MYY,
-            REF_FORCE_EL1D_MZZ,
-            REF_FORCE_EL1D_MOM,
+        REF_FORCE_EL1D = 14002000,
+        REF_FORCE_EL1D_FX,
+        REF_FORCE_EL1D_FY,
+        REF_FORCE_EL1D_FZ,
+        REF_FORCE_EL1D_FRC,
+        REF_FORCE_EL1D_MXX,
+        REF_FORCE_EL1D_MYY,
+        REF_FORCE_EL1D_MZZ,
+        REF_FORCE_EL1D_MOM,
 
-            REF_STRESS_EL1D = 14003000,
-            REF_STRESS_EL1D_A,
-            REF_STRESS_EL1D_SY,
-            REF_STRESS_EL1D_SZ,
-            REF_STRESS_EL1D_BY_POSZ,
-            REF_STRESS_EL1D_BY_NEGZ,
-            REF_STRESS_EL1D_BZ_POSY,
-            REF_STRESS_EL1D_BZ_NEGY,
-            REF_STRESS_EL1D_C1,
-            REF_STRESS_EL1D_C2,
-            REF_STRESS_EL1D_CY,
-            REF_STRESS_EL1D_CZ,
+        REF_STRESS_EL1D = 14003000,
+        REF_STRESS_EL1D_A,
+        REF_STRESS_EL1D_SY,
+        REF_STRESS_EL1D_SZ,
+        REF_STRESS_EL1D_BY_POSZ,
+        REF_STRESS_EL1D_BY_NEGZ,
+        REF_STRESS_EL1D_BZ_POSY,
+        REF_STRESS_EL1D_BZ_NEGY,
+        REF_STRESS_EL1D_C1,
+        REF_STRESS_EL1D_C2,
+        REF_STRESS_EL1D_CY,
+        REF_STRESS_EL1D_CZ,
 
-            REF_STRESS_EL1D_DRV = 14003200,
-            REF_STRESS_EL1D_DRV_SY,
-            REF_STRESS_EL1D_DRV_SZ,
-            REF_STRESS_EL1D_DRV_ST,
-            REF_STRESS_EL1D_DRV_V_MISES,
+        REF_STRESS_EL1D_DRV = 14003200,
+        REF_STRESS_EL1D_DRV_SY,
+        REF_STRESS_EL1D_DRV_SZ,
+        REF_STRESS_EL1D_DRV_ST,
+        REF_STRESS_EL1D_DRV_V_MISES,
 
-            REF_STRAIN_EL1D = 14003500,
-            REF_STRAIN_EL1D_A,
+        REF_STRAIN_EL1D = 14003500,
+        REF_STRAIN_EL1D_A,
 
-            REF_SED_EL1D = 14004000,
-            REF_SED_EL1D_WEB,
-            REF_SED_EL1D_FLG,
-            REF_SED_EL1D_TOT,
+        REF_SED_EL1D = 14004000,
+        REF_SED_EL1D_WEB,
+        REF_SED_EL1D_FLG,
+        REF_SED_EL1D_TOT,
 
-            REF_SED_AVG_EL1D = 14005000,
-            REF_SED_AVG_EL1D_WEB,
-            REF_SED_AVG_EL1D_FLG,
-            REF_SED_AVG_EL1D_TOT,
+        REF_SED_AVG_EL1D = 14005000,
+        REF_SED_AVG_EL1D_WEB,
+        REF_SED_AVG_EL1D_FLG,
+        REF_SED_AVG_EL1D_TOT,
 
-            REF_STL_UTIL = 14006000,
-            REF_STL_UTIL_OVER_ALL,
-            REF_STL_UTIL_LCL_COMB,
-            REF_STL_UTIL_BCK_COMB,
-            REF_STL_UTIL_LCL_A,
-            REF_STL_UTIL_LCL_SU,
-            REF_STL_UTIL_LCL_SV,
-            REF_STL_UTIL_LCL_MXX,
-            REF_STL_UTIL_LCL_MUU,
-            REF_STL_UTIL_LCL_MVV,
-            REF_STL_UTIL_BCK_UU,
-            REF_STL_UTIL_BCK_VV,
-            REF_STL_UTIL_BCK_LT,
-            REF_STL_UTIL_BCK_TOR,
-            REF_STL_UTIL_BCK_FT,
-        }
+        REF_STL_UTIL = 14006000,
+        REF_STL_UTIL_OVER_ALL,
+        REF_STL_UTIL_LCL_COMB,
+        REF_STL_UTIL_BCK_COMB,
+        REF_STL_UTIL_LCL_A,
+        REF_STL_UTIL_LCL_SU,
+        REF_STL_UTIL_LCL_SV,
+        REF_STL_UTIL_LCL_MXX,
+        REF_STL_UTIL_LCL_MUU,
+        REF_STL_UTIL_LCL_MVV,
+        REF_STL_UTIL_BCK_UU,
+        REF_STL_UTIL_BCK_VV,
+        REF_STL_UTIL_BCK_LT,
+        REF_STL_UTIL_BCK_TOR,
+        REF_STL_UTIL_BCK_FT,
+    }
 
-        /***************************************/
+    /***************************************/
 
-        public enum Out_1D_Properties
-        {
-            REF_ELEM = 1011000,
-            REF_ELEM_NAME,
-            REF_ELEM_TYPE,
-            REF_ELEM_PROP,
-            REF_ELEM_GROUP,
-            REF_ELEM_NODE,
-            REF_ELEM_ANGLE,
-            REF_ELEM_VERT,
-            REF_ELEM_LEN,
-            REF_ELEM_TOPO,
-        }
+    public enum Out_1D_Properties
+    {
+        REF_ELEM = 1011000,
+        REF_ELEM_NAME,
+        REF_ELEM_TYPE,
+        REF_ELEM_PROP,
+        REF_ELEM_GROUP,
+        REF_ELEM_NODE,
+        REF_ELEM_ANGLE,
+        REF_ELEM_VERT,
+        REF_ELEM_LEN,
+        REF_ELEM_TOPO,
+    }
 
-        /***************************************/
+    /***************************************/
 
-        public enum Output_Init_Flags
-        {
-            //These are hexadecimals. "0x" represents the hexadecimal representation of a subsequent number.
-            OP_INIT_2D_BOTTOM = 0x1,     // output 2D stresses at bottom layer
-            OP_INIT_2D_MIDDLE = 0x2,     // output 2D stresses at middle layer
-            OP_INIT_2D_TOP = 0x4,        // output 2D stresses at top layer
-            OP_INIT_2D_BENDING = 0x8,    // output 2D stresses at bending layer
-            OP_INIT_2D_AVGE = 0x10,      // average 2D element stresses at nodes
-            OP_INIT_1D_AUTO_PTS = 0x20,  // calculate 1D results at interesting points
-        }
+    public enum Output_Init_Flags
+    {
+        //These are hexadecimals. "0x" represents the hexadecimal representation of a subsequent number.
+        OP_INIT_2D_BOTTOM = 0x1,     // output 2D stresses at bottom layer
+        OP_INIT_2D_MIDDLE = 0x2,     // output 2D stresses at middle layer
+        OP_INIT_2D_TOP = 0x4,        // output 2D stresses at top layer
+        OP_INIT_2D_BENDING = 0x8,    // output 2D stresses at bending layer
+        OP_INIT_2D_AVGE = 0x10,      // average 2D element stresses at nodes
+        OP_INIT_1D_AUTO_PTS = 0x20,  // calculate 1D results at interesting points
+        OP_INIT_INFINITY = 0x40      //infinity and NaN values as such, else as zero
+    }
 
-        /***************************************/
+    /***************************************/
 
-        //In lack of an "Estring" function we have created a static class which returns
-        //the three different options of outputaxis. It's used when extracting info in SIGSA.
-        public static class Output_Axis
-        {
-            static public string Default() { return "default"; }
-            static public string Global() { return "global"; }
-            static public string Local() { return "local"; }
-        }
+    //In lack of an "Estring" function we have created a static class which returns
+    //the three different options of outputaxis. It's used when extracting info in SIGSA.
+    public static class Output_Axis
+    {
+        static public string Default() { return "default"; }
+        static public string Global() { return "global"; }
+        static public string Local() { return "local"; }
+    }
 
-        /***************************************/
+    /***************************************/
 
-        public enum UnitType
-        {
-            FORCE = 0,
-            LENGTH,
-            DISP,
-            SECTION,
-            MASS,
-            TIME,
-            TEMP,
-            STRESS,
-            ACCEL,
-            ENERGY
-        }
+    public enum UnitType
+    {
+        FORCE = 0,
+        LENGTH,
+        DISP,
+        SECTION,
+        MASS,
+        TIME,
+        TEMP,
+        STRESS,
+        ACCEL,
+        ENERGY
+    }
 
-        /***************************************/
+    /***************************************/
 
-        public enum LoadType
-        {
-            DEAD,
-            IMPOSED,
-            WIND,
-            SNOW,
-            NOTIONAL,
-            SEISMIC,
-            UNDEF
-        }
+    public enum LoadType
+    {
+        DEAD,
+        IMPOSED,
+        WIND,
+        SNOW,
+        NOTIONAL,
+        SEISMIC,
+        UNDEF
+    }
 
-        /***************************************/
+    /***************************************/
 
-        public enum MaterialType
-        {
-            MT_STEEL,
-            MT_CONCRETE,
-            MT_ALUMINIUM,
-            MT_GLASS,
-            MT_TIMBER,
-            MT_UNDEF,
-            MT_REBAR
-        }
+    public enum MaterialType
+    {
+        MT_STEEL,
+        MT_CONCRETE,
+        MT_ALUMINIUM,
+        MT_GLASS,
+        MT_TIMBER,
+        MT_UNDEF,
+        MT_REBAR
+    }
 
-        /***************************************/
-    
+    /***************************************/
+
 }

--- a/GSA_Engine/Convert/ToBHoM.cs
+++ b/GSA_Engine/Convert/ToBHoM.cs
@@ -996,9 +996,9 @@ namespace BH.Engine.GSA
 
         /***************************************************/
 
-        public static BarDeformation ToBHoMBarDeformation(GsaResults results, string id, string loadCase, int divisions, double timeStep = 0)
+        public static BarDisplacement ToBHoMBarDisplacement(GsaResults results, string id, string loadCase, int divisions, double timeStep = 0)
         {
-            BarDeformation def = new BarDeformation
+            BarDisplacement disp = new BarDisplacement
             {
                 ObjectId = id,
                 ResultCase = loadCase,
@@ -1012,7 +1012,7 @@ namespace BH.Engine.GSA
                 RY = results.dynaResults[5],
                 RZ = results.dynaResults[6]
             };
-            return def;
+            return disp;
         }
 
         /***************************************************/


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #126 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/GSA_Toolkit/GSA_Toolkit-Issue126-ReadResultUpdate?csf=1&e=rEcEy2

Code will work without it, but to be able to view deformed shape, https://github.com/BHoM/BHoM_Engine/pull/1350 is needed

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Update result extraction to work with ResultRequests. Support for BarResultRequest, NodeResultRequest and GlobalResultRequest added.
- For BarResult this now means better control over how results are extracted.
- Outputting BarDisplacements instead of BarDeformations.
- Updated warning and error messaging

 ### Additional comments
<!-- As required -->
