### PR TITLE
Fix bug for GSA failing to push box sections with specific names

### DIFF
--- a/GSA_Engine/Convert/Private Helpers/SectionProperty.cs
+++ b/GSA_Engine/Convert/Private Helpers/SectionProperty.cs
@@ -58,7 +58,8 @@ namespace BH.Engine.GSA
                         else if (steel.SectionProfile.Shape == ShapeType.Box || steel.SectionProfile.Shape == ShapeType.Tube)
                         {
                             //Add tailing .0 for closed sections
-                            if (arr[1].ToCharArray()[arr[1].Length - 2] != '.')
+                            char[] chArr = arr[1].ToCharArray();
+                            if (chArr.Length > 2 && chArr[arr[1].Length - 2] != '.')
                             {
                                 arr[1] += ".0";
                             }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #44 

 <!-- Add short description of what has been fixed -->

For boxes with names containing a space that had fewer than 2 chars in the second part after the space the adapter crashed due to index out of bounds. A check of the length of the array has not been added to avoid this.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/01_Test%20Scripts/GSA_Toolkit/GSA_Toolkit-Issue44-BoxSectionsFailForSpecificNames?csf=1&e=sHOevd

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
