### PR TITLE
GSA_Toolkit: Add support for timber aluminium and generic sections

### DIFF
--- a/GSA_Adapter/GSAAdapter.cs
+++ b/GSA_Adapter/GSAAdapter.cs
@@ -89,7 +89,12 @@ namespace BH.Adapter.GSA
 
         private bool ComCall(string str, bool raiseError = true)
         {
-            dynamic commandResult = m_gsaCom.GwaCommand(str);
+            dynamic commandResult;
+
+            if (!string.IsNullOrWhiteSpace(str))
+                commandResult = m_gsaCom.GwaCommand(str);
+            else
+                return false;
 
             if (1 == (int)commandResult)
                 return true;

--- a/GSA_Engine/Compute/NotSupportedWarning.cs
+++ b/GSA_Engine/Compute/NotSupportedWarning.cs
@@ -1,0 +1,48 @@
+﻿/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2019, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+using System;
+using System.Linq;
+using System.Collections.Generic;
+using System.ComponentModel;
+using BH.oM.Reflection.Attributes;
+using BH.oM.Base;
+
+namespace BH.Engine.GSA
+{
+    public static partial class Compute
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        [Description("Raises a warning for types not supported")]
+        [Input("type", "The type not supported")]
+        [Input("category", "The object category to raise a warning for. Defaults to object")]
+        public static void NotSupportedWarning(Type type, string category = "Objects")
+        {
+            Engine.Reflection.Compute.RecordWarning(category + " of type " + type.FullName + " are not suppoerted in this the GSA Adapter");
+        }
+
+        /***************************************************/
+    }
+}

--- a/GSA_Engine/Compute/NotSupportedWarning.cs
+++ b/GSA_Engine/Compute/NotSupportedWarning.cs
@@ -40,7 +40,7 @@ namespace BH.Engine.GSA
         [Input("category", "The object category to raise a warning for. Defaults to object")]
         public static void NotSupportedWarning(Type type, string category = "Objects")
         {
-            Engine.Reflection.Compute.RecordWarning(category + " of type " + type.FullName + " are not suppoerted in this the GSA Adapter");
+            Engine.Reflection.Compute.RecordWarning(category + " of type " + type.FullName + " are not suppoerted in the GSA Adapter");
         }
 
         /***************************************************/

--- a/GSA_Engine/Compute/NotSupportedWarning.cs
+++ b/GSA_Engine/Compute/NotSupportedWarning.cs
@@ -40,7 +40,7 @@ namespace BH.Engine.GSA
         [Input("category", "The object category to raise a warning for. Defaults to object")]
         public static void NotSupportedWarning(Type type, string category = "Objects")
         {
-            Engine.Reflection.Compute.RecordWarning(category + " of type " + type.FullName + " are not suppoerted in the GSA Adapter");
+            Engine.Reflection.Compute.RecordWarning(category + " of type " + type.FullName + " are not supported in the GSA Adapter");
         }
 
         /***************************************************/

--- a/GSA_Engine/Convert/Private Helpers/SectionProperty.cs
+++ b/GSA_Engine/Convert/Private Helpers/SectionProperty.cs
@@ -147,7 +147,7 @@ namespace BH.Engine.GSA
             //This will handle Steel, Concrete, Aluminium, Timber and Generi section, i.e. all profile based sections, the same way.
             prop = "NO_PROP";
             desc = "";
-            Reflection.Compute.RecordWarning("Section property of type " + secProp.GetType().Name + " is not suppoerted in the GSA Adapter");
+            Compute.NotSupportedWarning(secProp.GetType(), "Section properties");
             return false; 
         }
 
@@ -335,7 +335,7 @@ namespace BH.Engine.GSA
 
         private static bool CreateDescString(IProfile profile, out string desc)
         {
-            Reflection.Compute.RecordWarning("Profile of type " + profile.GetType().Name + " is not suppoerted in the GSA Adapter");
+            Compute.NotSupportedWarning(profile.GetType(), "Section profiles");
             desc = "";
             return false;
         }

--- a/GSA_Engine/Convert/Private Helpers/SectionProperty.cs
+++ b/GSA_Engine/Convert/Private Helpers/SectionProperty.cs
@@ -135,6 +135,7 @@ namespace BH.Engine.GSA
         private static bool CreateDescAndPropString(IGeometricalSection secProp, out string desc, out string prop)
         {
             //This will handle Steel, Concrete, Aluminium, Timber and Generi section, i.e. all profile based sections, the same way.
+            //If reinforement for concrete is to be added, this needs to be handled separately.
             prop = "NO_PROP";
             return ICreateDescString(secProp.SectionProfile, out desc);
         }

--- a/GSA_Engine/Convert/Private Helpers/SectionProperty.cs
+++ b/GSA_Engine/Convert/Private Helpers/SectionProperty.cs
@@ -144,7 +144,7 @@ namespace BH.Engine.GSA
 
         private static bool CreateDescAndPropString(ISectionProperty secProp, out string desc, out string prop)
         {
-            //This will handle Steel, Concrete, Aluminium, Timber and Generi section, i.e. all profile based sections, the same way.
+            //Fallback method for section types not implemented.
             prop = "NO_PROP";
             desc = "";
             Compute.NotSupportedWarning(secProp.GetType(), "Section properties");

--- a/GSA_Engine/Convert/Private Helpers/SectionProperty.cs
+++ b/GSA_Engine/Convert/Private Helpers/SectionProperty.cs
@@ -131,18 +131,23 @@ namespace BH.Engine.GSA
         }
 
         /***************************************/
-        private static bool CreateDescAndPropString(SteelSection secProp, out string desc, out string prop)
+
+        private static bool CreateDescAndPropString(IGeometricalSection secProp, out string desc, out string prop)
         {
+            //This will handle Steel, Concrete, Aluminium, Timber and Generi section, i.e. all profile based sections, the same way.
             prop = "NO_PROP";
             return ICreateDescString(secProp.SectionProfile, out desc);
         }
 
         /***************************************/
-        private static bool CreateDescAndPropString(ConcreteSection secProp, out string desc, out string prop)
+
+        private static bool CreateDescAndPropString(ISectionProperty secProp, out string desc, out string prop)
         {
-            //TODO: Reinforcement???
+            //This will handle Steel, Concrete, Aluminium, Timber and Generi section, i.e. all profile based sections, the same way.
             prop = "NO_PROP";
-            return ICreateDescString(secProp.SectionProfile, out desc);
+            desc = "";
+            Reflection.Compute.RecordWarning("Section proeprty of type " + secProp.GetType().Name + " is not suppoerted in this adapter");
+            return false; 
         }
 
         /***************************************/

--- a/GSA_Engine/Convert/Private Helpers/SectionProperty.cs
+++ b/GSA_Engine/Convert/Private Helpers/SectionProperty.cs
@@ -146,7 +146,7 @@ namespace BH.Engine.GSA
             //This will handle Steel, Concrete, Aluminium, Timber and Generi section, i.e. all profile based sections, the same way.
             prop = "NO_PROP";
             desc = "";
-            Reflection.Compute.RecordWarning("Section proeprty of type " + secProp.GetType().Name + " is not suppoerted in this adapter");
+            Reflection.Compute.RecordWarning("Section property of type " + secProp.GetType().Name + " is not suppoerted in the GSA Adapter");
             return false; 
         }
 
@@ -246,13 +246,6 @@ namespace BH.Engine.GSA
 
         /***************************************/
 
-        private static bool CreateDescString(ZSectionProfile dimensions, out string desc)
-        {
-            throw new NotSupportedException("Zed sections are currently not supported in the GSA adapter");
-        }
-
-        /***************************************/
-
         private static bool CreateDescString(ISectionProfile dimensions, out string desc)
         {
             double h, w, tw, tf;
@@ -339,9 +332,11 @@ namespace BH.Engine.GSA
 
         /***************************************/
 
-        private static bool CreateDescString(FreeFormProfile profile, out string desc)
+        private static bool CreateDescString(IProfile profile, out string desc)
         {
-            throw new NotImplementedException();
+            Reflection.Compute.RecordWarning("Profile of type " + profile.GetType().Name + " is not suppoerted in the GSA Adapter");
+            desc = "";
+            return false;
         }
 
         /***************************************/

--- a/GSA_Engine/Convert/ToBHoM.cs
+++ b/GSA_Engine/Convert/ToBHoM.cs
@@ -620,6 +620,7 @@ namespace BH.Engine.GSA
                             return null;
                     }
 
+                    //Creates a section based on the material type provided, with fallback to Generic
                     secProp = Structure.Create.SectionPropertyFromProfile(dimensions, mat, "");
 
                 }

--- a/GSA_Engine/Convert/ToBHoM.cs
+++ b/GSA_Engine/Convert/ToBHoM.cs
@@ -620,22 +620,13 @@ namespace BH.Engine.GSA
                             return null;
                     }
 
-                    if (mat is BHM.Steel)
-                        secProp = Structure.Create.SteelSectionFromProfile(dimensions);
-                    else if (mat is BHM.Concrete)
-                        secProp = Structure.Create.ConcreteSectionFromProfile(dimensions);
-                    else
-                    {
-                        Reflection.Compute.RecordError("Material type " + mat.GetType().Name + " for cross section not implemented");
-                        return null;
-                    }
+                    secProp = Structure.Create.SectionPropertyFromProfile(dimensions, mat, "");
 
                 }
             }
 
             secProp.CustomData[AdapterIdName] = id;
             secProp.ApplyTaggedName(gsaStrings[2]);
-            secProp.Material = mat;
             return secProp;
         }
 

--- a/GSA_Engine/Convert/ToBHoM.cs
+++ b/GSA_Engine/Convert/ToBHoM.cs
@@ -302,47 +302,104 @@ namespace BH.Engine.GSA
             if (gStr.Length < 11)
                 return null;
 
-            //BHMF.MaterialType type = GetTypeFromString(gStr[5]);
-
-            double E, v, tC, G, rho;
-
-            if (!double.TryParse(gStr[7], out E))
-                return null;
-            if (!double.TryParse(gStr[8], out v))
-                return null;
-            if (!double.TryParse(gStr[10], out tC))
-                return null;
-            if (!double.TryParse(gStr[11], out G))
-                return null;
-            if (!double.TryParse(gStr[9], out rho))
-                return null;
-
             BHM.IMaterialFragment mat;
 
-
-            switch (gStr[5])
+            if (gStr[2] == "MAT_ELAS_ISO")
             {
-                case "MT_ALUMINIUM":
-                    mat = Engine.Structure.Create.Aluminium("", E, v, tC, rho);
-                    break;
-                case "MT_CONCRETE":
-                    mat = Structure.Create.Concrete("", E, v, tC, rho);
-                    break;
-                case "MT_STEEL":
-                case "MT_REBAR":
-                    mat = Structure.Create.Steel("", E, v, tC, rho);
-                    break;
-                case "MT_UNDEF":
-                    mat = Structure.Create.Steel("", E, v, tC, rho);
-                    Engine.Reflection.Compute.RecordWarning(string.Format("Material with id {0} and name {1} has no type defined. A steel material will be assumed", gStr[1], gStr[3]));
-                    break;
-                case "MT_TIMBER":
-                case "MT_GLASS":
-                default:
-                    Engine.Reflection.Compute.RecordWarning("Pulling material of type " + gStr[5] + " is not supported. Material with name " + gStr[3] + " failed");
+                //BHMF.MaterialType type = GetTypeFromString(gStr[5]);
+
+                double E, v, tC, G, rho;
+
+                if (!double.TryParse(gStr[7], out E))
                     return null;
+                if (!double.TryParse(gStr[8], out v))
+                    return null;
+                if (!double.TryParse(gStr[10], out tC))
+                    return null;
+                if (!double.TryParse(gStr[11], out G))
+                    return null;
+                if (!double.TryParse(gStr[9], out rho))
+                    return null;
+
+                switch (gStr[5])
+                {
+                    case "MT_ALUMINIUM":
+                        mat = Engine.Structure.Create.Aluminium("", E, v, tC, rho);
+                        break;
+                    case "MT_CONCRETE":
+                        mat = Structure.Create.Concrete("", E, v, tC, rho);
+                        break;
+                    case "MT_STEEL":
+                    case "MT_REBAR":
+                        mat = Structure.Create.Steel("", E, v, tC, rho);
+                        break;
+                    case "MT_TIMBER":
+                        mat = Structure.Create.Timber("", new Vector { X = E, Y = E, Z = E }, new Vector { X = v, Y = v, Z = v }, new Vector { X = G, Y = G, Z = G }, new Vector { X = tC, Y = tC, Z = tC }, rho, 0);
+                        break;
+                    default:
+                        mat = new oM.Structure.MaterialFragments.GenericIsotropicMaterial { YoungsModulus = E, Density = rho, PoissonsRatio = v, ThermalExpansionCoeff = tC };
+                        Engine.Reflection.Compute.RecordWarning(string.Format("Material with id {0} and name {1} is of a type not currently fully supported or has no type defined. A generic isotropic material will be assumed", gStr[1], gStr[3]));
+                        break;
+
+                }
             }
-        
+            else if (gStr[2] == "MAT_ELAS_ORTHO")
+            {
+                double E1, E2, E3, v1, v2, v3, tC1, tC2, tC3, G1, G2, G3, rho;
+
+                if (!double.TryParse(gStr[7], out E1))
+                    return null;
+                if (!double.TryParse(gStr[8], out E2))
+                    return null;
+                if (!double.TryParse(gStr[9], out E3))
+                    return null;
+
+                if (!double.TryParse(gStr[10], out v1))
+                    return null;
+                if (!double.TryParse(gStr[11], out v2))
+                    return null;
+                if (!double.TryParse(gStr[12], out v3))
+                    return null;
+
+                if (!double.TryParse(gStr[13], out rho))
+                    return null;
+
+                if (!double.TryParse(gStr[14], out tC1))
+                    return null;
+                if (!double.TryParse(gStr[15], out tC2))
+                    return null;
+                if (!double.TryParse(gStr[16], out tC3))
+                    return null;
+
+                if (!double.TryParse(gStr[17], out G1))
+                    return null;
+                if (!double.TryParse(gStr[18], out G2))
+                    return null;
+                if (!double.TryParse(gStr[19], out G3))
+                    return null;
+
+                Vector e = new Vector { X = E1, Y = E2, Z = E3 };
+                Vector v = new Vector { X = v1, Y = v2, Z = v3 };
+                Vector tC = new Vector { X = tC1, Y = tC2, Z = tC3 };
+                Vector g = new Vector { X = G1, Y = G2, Z = G3 };
+
+                switch (gStr[5])
+                {
+
+                    case "MT_TIMBER":
+                        mat = Structure.Create.Timber("", e, v, g, tC, rho, 0);
+                        break;
+                    default:
+                        mat = new oM.Structure.MaterialFragments.GenericOrthotropicMaterial { YoungsModulus = e, ShearModulus = g, Density = rho, ThermalExpansionCoeff = tC, PoissonsRatio = v };
+                        Engine.Reflection.Compute.RecordWarning(string.Format("Material with id {0} and name {1} is of a type not currently fully supported or has no orthotropic type defined. A generic orthotropic material will be assumed", gStr[1], gStr[3]));
+                        break;
+
+                }
+            }
+            else
+            {
+                return null;
+            }
 
 
             mat.ApplyTaggedName(gStr[3]);

--- a/GSA_Engine/Convert/ToGsa.cs
+++ b/GSA_Engine/Convert/ToGsa.cs
@@ -278,7 +278,7 @@ namespace BH.Engine.GSA
                 string G = CommaSeparatedValues(orthotropic.ShearModulus);
                 string damp = orthotropic.DampingRatio.ToString();
 
-                string str = command + "," + num + "," + mModel + "," + name + "," + colour + "," + type + ",6," + E + "," + nu + "," + rho + "," + alpha + "," + G + "," + damp + ",0,0,NO_ENV";
+                string str = command + "," + num + "," + mModel + "," + name + "," + colour + "," + type + ",14," + E + "," + nu + "," + rho + "," + alpha + "," + G + "," + damp + ",0,0,NO_ENV";
                 return str;
             }
             else

--- a/GSA_Engine/Convert/ToGsa.cs
+++ b/GSA_Engine/Convert/ToGsa.cs
@@ -317,7 +317,8 @@ namespace BH.Engine.GSA
             string desc;
             string props;
 
-            ICreateDescAndPropString(prop, out desc, out props);
+            if (!ICreateDescAndPropString(prop, out desc, out props))
+                return "";
 
             string command = "PROP_SEC";
             string colour = "NO_RGB";

--- a/GSA_Engine/Convert/ToGsa.cs
+++ b/GSA_Engine/Convert/ToGsa.cs
@@ -283,7 +283,7 @@ namespace BH.Engine.GSA
             }
             else
             {
-                Engine.Reflection.Compute.RecordWarning("GSA_Toolkit does currently only suport Isotropic material. Material with name " + material.Name + " have been NOT been pushed");
+                Engine.Reflection.Compute.RecordWarning("GSA_Toolkit does currently only suport Isotropic and Orthotropic materials. Material with name " + material.Name + " has NOT been pushed");
                 return "";
             }
         }

--- a/GSA_Engine/Convert/ToGsa.cs
+++ b/GSA_Engine/Convert/ToGsa.cs
@@ -502,7 +502,7 @@ namespace BH.Engine.GSA
 
         public static string ToGsaString(this object obj, string index)
         {
-            Engine.Reflection.Compute.RecordWarning("Objects of type " + obj.GetType().Name + " are not suppoerted in this Adapter");
+            Compute.NotSupportedWarning(obj.GetType());
             return "";
         }
 
@@ -510,7 +510,8 @@ namespace BH.Engine.GSA
 
         public static string ToGsaString(this Panel obj, string index)
         {
-            Engine.Reflection.Compute.RecordWarning("GSA has no meshing capabilities and does therefor not support Panel objects. Try meshing the panel and create a FEMesh and then push again");
+            Engine.Reflection.Compute.RecordWarning("GSA has no meshing capabilities and does therefore not support Panel objects. \n"+
+                                                    "To be able to push a Panel it first needs to be meshed and turned into a FEMesh.");
             return "";
         }
 

--- a/GSA_Engine/Convert/ToGsa.cs
+++ b/GSA_Engine/Convert/ToGsa.cs
@@ -469,6 +469,23 @@ namespace BH.Engine.GSA
             return ToGsaString(obj as dynamic, index);
         }
 
+        /***************************************************/
+        /**** Private fallback                          ****/
+        /***************************************************/
+
+        public static string ToGsaString(this object obj, string index)
+        {
+            Engine.Reflection.Compute.RecordWarning("Objects of type " + obj.GetType().Name + " are not suppoerted in this Adapter");
+            return "";
+        }
+
+        /***************************************/
+
+        public static string ToGsaString(this Panel obj, string index)
+        {
+            Engine.Reflection.Compute.RecordWarning("GSA has no meshing capabilities and does therefor not support Panel objects. Try meshing the panel and create a FEMesh and then push again");
+            return "";
+        }
 
         /***************************************/
     }

--- a/GSA_Engine/Convert/ToGsa.cs
+++ b/GSA_Engine/Convert/ToGsa.cs
@@ -262,11 +262,37 @@ namespace BH.Engine.GSA
                 string str = command + "," + num + "," + mModel + "," + name + "," + colour + "," + type + ",6," + E + "," + nu + "," + rho + "," + alpha + "," + G + "," + damp + ",0,0,NO_ENV";
                 return str;
             }
-           else
+            else if(material is IOrthotropic)
+            {
+                IOrthotropic orthotropic = material as IOrthotropic;
+                string command = "MAT";
+                string num = index;
+                string mModel = "MAT_ELAS_ORTHO";
+                string name = material.TaggedName();
+                string colour = "NO_RGB";
+                string type = GetMaterialType(material).ToString();
+                string E = CommaSeparatedValues(orthotropic.YoungsModulus);
+                string nu = CommaSeparatedValues(orthotropic.PoissonsRatio);
+                string rho = orthotropic.Density.ToString();
+                string alpha = CommaSeparatedValues(orthotropic.ThermalExpansionCoeff);
+                string G = CommaSeparatedValues(orthotropic.ShearModulus);
+                string damp = orthotropic.DampingRatio.ToString();
+
+                string str = command + "," + num + "," + mModel + "," + name + "," + colour + "," + type + ",6," + E + "," + nu + "," + rho + "," + alpha + "," + G + "," + damp + ",0,0,NO_ENV";
+                return str;
+            }
+            else
             {
                 Engine.Reflection.Compute.RecordWarning("GSA_Toolkit does currently only suport Isotropic material. Material with name " + material.Name + " have been NOT been pushed");
                 return "";
             }
+        }
+
+        /***************************************/
+
+        private static string CommaSeparatedValues(Vector v)
+        {
+            return v.X + "," + v.Y + "," + v.Z;
         }
 
         /***************************************/

--- a/GSA_Engine/Convert/ToGsa.cs
+++ b/GSA_Engine/Convert/ToGsa.cs
@@ -283,7 +283,7 @@ namespace BH.Engine.GSA
             }
             else
             {
-                Engine.Reflection.Compute.RecordWarning("GSA_Toolkit does currently only suport Isotropic and Orthotropic materials. Material with name " + material.Name + " has NOT been pushed");
+                Engine.Reflection.Compute.RecordWarning("GSA_Toolkit does currently only support Isotropic and Orthotropic materials. Material with name " + material.Name + " has NOT been pushed");
                 return "";
             }
         }

--- a/GSA_Engine/GSA_Engine.csproj
+++ b/GSA_Engine/GSA_Engine.csproj
@@ -112,6 +112,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Compute\NotSupportedWarning.cs" />
     <Compile Include="Convert\AdapterID.cs" />
     <Compile Include="Convert\ToBHoM.cs" />
     <Compile Include="Convert\Private Helpers\Bar.cs" />


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #136 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/Eq3mvzxjQfFCh9_JWf79nigBWQmBvXZMbDccVIN4f7JAtQ?e=AVnqMk

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Added support for Timber, Aluminium and Generic section types
- Added more descriptive warnings for unsupported types/sections/profiles
- Added explicit warning and suggestion for Panel
- Added support for Orthotropic materials in read/write

 ### Additional comments
<!-- As required -->
