### PR TITLE
Description or Name comparer and section and material fixes

### DIFF
--- a/GSA_Adapter/Convert/ToGsa/Properties/LinkConstraint.cs
+++ b/GSA_Adapter/Convert/ToGsa/Properties/LinkConstraint.cs
@@ -21,6 +21,8 @@
  */
 
 using BH.oM.Structure.Constraints;
+using BH.Engine.Structure;
+using BH.Engine.Serialiser;
 
 namespace BH.Adapter.GSA
 {
@@ -33,7 +35,8 @@ namespace BH.Adapter.GSA
         private static string ToGsaString(LinkConstraint constraint, string index)
         {
             string command = "PROP_LINK";
-            string name = constraint.Name;
+            constraint.Name = constraint.DescriptionOrName();
+            string name = constraint.TaggedName();
             string restraint = GetRestraintString(constraint);
             return command + ", " + index + ", " + name + ", NO_RGB, " + restraint;
         }

--- a/GSA_Adapter/Convert/ToGsa/Properties/SectionProperty.cs
+++ b/GSA_Adapter/Convert/ToGsa/Properties/SectionProperty.cs
@@ -21,6 +21,7 @@
  */
 
 using BH.Engine.Serialiser;
+using BH.Engine.Structure;
 using BH.oM.Structure.SectionProperties;
 using BH.oM.Geometry.ShapeProfiles;
 using System;
@@ -36,6 +37,7 @@ namespace BH.Adapter.GSA
 
         private static string ToGsaString(this ISectionProperty prop, string index)
         {
+            prop.Name = prop.DescriptionOrName();
             string name = prop.TaggedName();
 
             string mat = prop.Material.CustomData[AdapterIdName].ToString();// materialId;  //"STEEL";// material.Name;

--- a/GSA_Adapter/Convert/ToGsa/Properties/SurfaceProperties.cs
+++ b/GSA_Adapter/Convert/ToGsa/Properties/SurfaceProperties.cs
@@ -22,6 +22,7 @@
 
 using BH.Engine.Serialiser;
 using BH.oM.Structure.SurfaceProperties;
+using BH.Engine.Structure;
 
 
 namespace BH.Adapter.GSA
@@ -34,6 +35,7 @@ namespace BH.Adapter.GSA
        
         private static string ToGsaString(ConstantThickness panProp, string index)
         {
+            panProp.Name = panProp.DescriptionOrName();
             string name = panProp.TaggedName();
             string mat = panProp.Material.CustomData[AdapterIdName].ToString();
 
@@ -56,6 +58,7 @@ namespace BH.Adapter.GSA
         private static string ToGsaString(LoadingPanelProperty panProp, string index)
         {
             string command = "PROP_2D";
+            panProp.Name = panProp.DescriptionOrName();
             string name = panProp.TaggedName();
             string colour = "NO_RGB";
             string axis = "0";

--- a/GSA_Adapter/GSAAdapter.cs
+++ b/GSA_Adapter/GSAAdapter.cs
@@ -33,6 +33,7 @@ using BH.oM.Structure.Constraints;
 using System.Collections.Generic;
 using BH.oM.Structure.SurfaceProperties;
 using BH.oM.Reflection.Attributes;
+using BH.Engine.Structure;
 
 namespace BH.Adapter.GSA
 {
@@ -50,11 +51,12 @@ namespace BH.Adapter.GSA
 
             AdapterComparers = new Dictionary<Type, object>
             {
-                {typeof(Bar), new BH.Engine.Structure.BarEndNodesDistanceComparer(3) },
-                {typeof(Node), new BH.Engine.Structure.NodeDistanceComparer(3) },
-                {typeof(ISectionProperty), new BHoMObjectNameOrToStringComparer() },
-                {typeof(IMaterialFragment), new BHoMObjectNameComparer() },
-                {typeof(LinkConstraint), new BHoMObjectNameComparer() },
+                {typeof(Bar), new BarEndNodesDistanceComparer(3) },
+                {typeof(Node), new NodeDistanceComparer(3) },
+                {typeof(ISectionProperty), new NameOrDescriptionComparer() },
+                {typeof(ISurfaceProperty), new NameOrDescriptionComparer() },
+                {typeof(IMaterialFragment), new NameOrDescriptionComparer() },
+                {typeof(LinkConstraint), new NameOrDescriptionComparer() },
             };
 
             DependencyTypes = new Dictionary<Type, List<Type>>


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Closes #169 
Closes #168 
Closes #163 

 <!-- Add short description of what has been fixed -->



 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->

- Making use of new DescriptionOrName comparer to be able to push structural properties without a name
- Return a correctly named Explicit section and raise an Error when failing to convert a section property
- Improve error messaging when pushing Orthotropic materials with null vectors

 ### Additional comments
<!-- As required -->
