### PR TITLE
Fixing modal dynamics extraction values

### DIFF
--- a/GSA_Adapter/CRUD/ReadResultsGlobal.cs
+++ b/GSA_Adapter/CRUD/ReadResultsGlobal.cs
@@ -83,11 +83,13 @@ namespace BH.Adapter.GSA
                     continue;
                 string frequency = m_gsaCom.GwaCommand("GET, FREQ, " + loadCase);
                 string mass = m_gsaCom.GwaCommand("GET, MASS, " + loadCase);
+                string inertia = m_gsaCom.GwaCommand("GET, INERTIA, " + loadCase);
+                string modalMass = m_gsaCom.GwaCommand("GET, MODAL_MASS, " + loadCase);
                 string damping = m_gsaCom.GwaCommand("GET, MODAL_DAMP, " + loadCase);
                 string stiffness = m_gsaCom.GwaCommand("GET, MODAL_STIFF, " + loadCase);
                 string effMassTran = m_gsaCom.GwaCommand("GET, EFF_MASS, " + loadCase + ",TRAN");
                 string effMassRot = m_gsaCom.GwaCommand("GET, EFF_MASS, " + loadCase + ",ROT");
-                dynamics.Add(BH.Adapter.GSA.Convert.FromGsaModalDynamics(id, mode, frequency, mass, stiffness, damping, effMassTran, effMassRot));
+                dynamics.Add(BH.Adapter.GSA.Convert.FromGsaModalDynamics(id, mode, frequency, mass, inertia, modalMass, stiffness, damping, effMassTran, effMassRot));
             }
 
             return dynamics;

--- a/GSA_Adapter/Convert/FromGsa/Results/Results.cs
+++ b/GSA_Adapter/Convert/FromGsa/Results/Results.cs
@@ -249,7 +249,7 @@ namespace BH.Adapter.GSA
 
         /***************************************************/
 
-        public static ModalDynamics FromGsaModalDynamics(string id, string mode, string frequency, string mass, string stiffness, string damping, string effMassTran, string effMassRot)
+        public static ModalDynamics FromGsaModalDynamics(string id, string mode, string frequency, string mass, string inertia, string modalMass, string stiffness, string damping, string effMassTran, string effMassRot)
         {
             string[] modeArr = mode.Split(',');
             string[] frArr = frequency.Split(',');
@@ -257,6 +257,8 @@ namespace BH.Adapter.GSA
             string[] stiArr = stiffness.Split(',');
             string[] tranArr = effMassTran.Split(',');
             string[] rotArr = effMassRot.Split(',');
+            string[] inertiaArr = inertia.Split(',');
+            string[] modMassArr = modalMass.Split(',');
             double damp;
             if (String.IsNullOrWhiteSpace(damping))
                 damp = 0;
@@ -264,6 +266,7 @@ namespace BH.Adapter.GSA
                 damp = double.Parse(damping.Split(',')[2]);
 
             double totMass = double.Parse(massArr[2]);
+            double modMass = double.Parse(modMassArr[2]);
             //TODO: Modal damping
 
             return new ModalDynamics(
@@ -272,15 +275,15 @@ namespace BH.Adapter.GSA
                 int.Parse(modeArr[2]),
                 0,
                 double.Parse(frArr[2]),
-                totMass,
+                modMass,
                 double.Parse(stiArr[2]),
                 damp,
                 double.Parse(tranArr[3]) / totMass,
                 double.Parse(tranArr[4]) / totMass,
                 double.Parse(tranArr[5]) / totMass,
-                double.Parse(rotArr[3]) / totMass,
-                double.Parse(rotArr[4]) / totMass,
-                double.Parse(rotArr[5]) / totMass
+                double.Parse(rotArr[3]) / double.Parse(inertiaArr[2]),
+                double.Parse(rotArr[4]) / double.Parse(inertiaArr[3]),
+                double.Parse(rotArr[5]) / double.Parse(inertiaArr[4])
                 );
         }
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

Does not depend on to compile, but needed to test: 
https://github.com/BHoM/BHoM/pull/999

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #193 

 <!-- Add short description of what has been fixed -->

Fix using the correct extracting values for MOdal mass and Inertia ratios

 ### Test files
<!-- Link to test files to validate the proposed changes -->

General Modal result extracting test file:

https://burohappold.sharepoint.com/:f:/s/BHoM/EszNjShmWNFJpiMmQ1EdM7ABAa3i7rfMe8oa54uHFtbwxg?e=aM6Kqr

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
