### PR TITLE
Add controls for setting residuals to be used for Non-linear tasks

### DIFF
--- a/GSA_Adapter/Convert/ToGsa/Loads/LoadCombination.cs
+++ b/GSA_Adapter/Convert/ToGsa/Loads/LoadCombination.cs
@@ -44,8 +44,9 @@ namespace BH.Adapter.GSA
             gsaStrings.Add(AnalysisCase(combNo, loadComb.Name, combNo, desc));
             AnalysisType type;
             int stage;
-            TaskTypeAndStage(loadComb, out type, out stage);
-            gsaStrings.Add(AnalysisTask(combNo, loadComb.Name, type, stage, combNo));
+            double residualForce, residualMoment;
+            TaskTypeAndStage(loadComb, out type, out stage, out residualForce, out residualMoment);
+            gsaStrings.Add(AnalysisTask(combNo, loadComb.Name, type, stage, combNo, residualForce, residualMoment));
 
             loadComb.SetAdapterId(typeof(BH.oM.Adapters.GSA.GSAId), "A" + loadComb.Number);
 
@@ -56,7 +57,7 @@ namespace BH.Adapter.GSA
         /**** Private Methods                           ****/
         /***************************************************/
 
-        private static void TaskTypeAndStage(LoadCombination comb, out AnalysisType type, out int stage)
+        private static void TaskTypeAndStage(LoadCombination comb, out AnalysisType type, out int stage, out double residualForce, out double residualMoment)
         {
             AnalysisTaskFragment fragment = comb.FindFragment<AnalysisTaskFragment>();
 
@@ -64,11 +65,15 @@ namespace BH.Adapter.GSA
             {
                 type = fragment.AnalysisType;
                 stage = fragment.Stage;
+                residualForce = fragment.ResidualForce;
+                residualMoment = fragment.ResidualMoment;
             }
             else
             {
                 type = AnalysisType.LinearStatic;
                 stage = 0;
+                residualForce = 1.0;
+                residualMoment = 1.0;
             }
         }
 
@@ -90,7 +95,7 @@ namespace BH.Adapter.GSA
 
         /***************************************************/
 
-        private static string AnalysisTask(string taskNo, string name, AnalysisType type, int stage, string anal_caseNo)
+        private static string AnalysisTask(string taskNo, string name, AnalysisType type, int stage, string anal_caseNo, double residualForce, double residualMoment)
         {
             string addTask;
             string command = "TASK";
@@ -120,6 +125,7 @@ namespace BH.Adapter.GSA
                     scheme = "SINGLE";
                     break;
             }
+
 
             if (type == AnalysisType.LinearStatic)
             {
@@ -168,8 +174,8 @@ namespace BH.Adapter.GSA
                     + ",CYCLE"
                     + ", 1000000"               //num_cycle 
                     + ", ABS"                   //rel_abs_residual 
-                    + ", 1"                     // force_residual 
-                    + ", 1"                     //moment_residual 
+                    + ", " + residualForce                     // force_residual 
+                    + ", " + residualMoment                     //moment_residual 
                     + ", DISP_CTRL_YES"
                     + ", 0"                     //disp_ctrl_node 
                     + ", 1"                     //disp_ctrl_dir 

--- a/GSA_Adapter/Convert/ToGsa/Loads/LoadCombination.cs
+++ b/GSA_Adapter/Convert/ToGsa/Loads/LoadCombination.cs
@@ -45,10 +45,11 @@ namespace BH.Adapter.GSA
             AnalysisType type;
             int stage;
             double residualForce, residualMoment;
-            TaskTypeAndStage(loadComb, out type, out stage, out residualForce, out residualMoment);
-            gsaStrings.Add(AnalysisTask(combNo, loadComb.Name, type, stage, combNo, residualForce, residualMoment));
+            string beamGeoStiffness;
+            TaskTypeAndStage(loadComb, out type, out stage, out residualForce, out residualMoment, out beamGeoStiffness);
+            gsaStrings.Add(AnalysisTask(combNo, loadComb.Name, type, stage, combNo, residualForce, residualMoment, beamGeoStiffness));
 
-            loadComb.SetAdapterId(typeof(BH.oM.Adapters.GSA.GSAId), "A" + loadComb.Number);
+            loadComb.SetAdapterId(typeof(GSAId), "A" + loadComb.Number);
 
             return gsaStrings;
         }
@@ -57,24 +58,19 @@ namespace BH.Adapter.GSA
         /**** Private Methods                           ****/
         /***************************************************/
 
-        private static void TaskTypeAndStage(LoadCombination comb, out AnalysisType type, out int stage, out double residualForce, out double residualMoment)
+        private static void TaskTypeAndStage(LoadCombination comb, out AnalysisType type, out int stage, out double residualForce, out double residualMoment, out string beamGeoStiffness)
         {
-            AnalysisTaskFragment fragment = comb.FindFragment<AnalysisTaskFragment>();
+            AnalysisTaskFragment fragment = comb.FindFragment<AnalysisTaskFragment>() ?? new AnalysisTaskFragment();
 
-            if (fragment != null)
-            {
-                type = fragment.AnalysisType;
-                stage = fragment.Stage;
-                residualForce = fragment.ResidualForce;
-                residualMoment = fragment.ResidualMoment;
-            }
+            type = fragment.AnalysisType;
+            stage = fragment.Stage;
+            residualForce = fragment.ResidualForce;
+            residualMoment = fragment.ResidualMoment;
+            if (fragment.BeamSlendernessEffect)
+                beamGeoStiffness = "BEAM_GEO_YES";
             else
-            {
-                type = AnalysisType.LinearStatic;
-                stage = 0;
-                residualForce = 1.0;
-                residualMoment = 1.0;
-            }
+                beamGeoStiffness = "BEAM_GEO_NO";
+
         }
 
         /***************************************************/
@@ -95,7 +91,7 @@ namespace BH.Adapter.GSA
 
         /***************************************************/
 
-        private static string AnalysisTask(string taskNo, string name, AnalysisType type, int stage, string anal_caseNo, double residualForce, double residualMoment)
+        private static string AnalysisTask(string taskNo, string name, AnalysisType type, int stage, string anal_caseNo, double residualForce, double residualMoment, string beamGeoStiffness)
         {
             string addTask;
             string command = "TASK";
@@ -166,7 +162,7 @@ namespace BH.Adapter.GSA
                     + "," + solution
                     + "," + scheme
                     + ", 1"                     //num_case 
-                    + ", BEAM_GEO_YES"
+                    + ", " + beamGeoStiffness
                     + ", SHELL_GEO_NO"
                     + ", 0.1"                   //first_inc
                     + ", 0.0001"                //min_inc 

--- a/GSA_Adapter/GSAAdapter.cs
+++ b/GSA_Adapter/GSAAdapter.cs
@@ -84,6 +84,7 @@ namespace BH.Adapter.GSA
                 {typeof(BH.oM.Structure.Loads.IElementLoad<Node>), new List<Type> { typeof(Node), typeof(BH.oM.Structure.Loads.Loadcase) } },
                 {typeof(BH.oM.Structure.Loads.IElementLoad<Bar>), new List<Type> { typeof(Bar), typeof(BH.oM.Structure.Loads.Loadcase) } },
                 {typeof(BH.oM.Structure.Loads.ILoad), new List<Type> { typeof(BH.oM.Structure.Loads.Loadcase) } },
+                {typeof(BH.oM.Structure.Loads.LoadCombination), new List<Type> { typeof(BH.oM.Structure.Loads.Loadcase) } },
                 {typeof(Bar), new List<Type> { typeof(ISectionProperty), typeof(Node) } },
                 {typeof(ISectionProperty), new List<Type> { typeof(IMaterialFragment) } },
                 {typeof(RigidLink), new List<Type> { typeof(LinkConstraint), typeof(Node) } },

--- a/GSA_Engine/GSA_Engine.csproj
+++ b/GSA_Engine/GSA_Engine.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -111,7 +111,7 @@
     <Compile Include="Create\GSAConfig.cs" />
     <Compile Include="Query\GSAId.cs" />
     <Compile Include="Modify\SetGSAId.cs" />
-    <Compile Include="Modify\SetAnalysisType.cs" />
+    <Compile Include="Modify\SetAnalysisSettings.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/GSA_Engine/GSA_Engine.csproj
+++ b/GSA_Engine/GSA_Engine.csproj
@@ -38,6 +38,7 @@
     <Reference Include="Analytical_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Analytical_oM.dll</HintPath>
       <Private>False</Private>
+	  <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="BHoM">
       <SpecificVersion>False</SpecificVersion>
@@ -62,6 +63,7 @@
     <Reference Include="Geometry_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Geometry_oM.dll</HintPath>
       <Private>False</Private>
+	  <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Interop.Gsa_8_7, Version=8.7.0.0, Culture=neutral, processorArchitecture=AMD64">
       <HintPath>..\packages\BHoM.Interop.GSA8_7.1.0.0\lib\net45\Interop.Gsa_8_7.dll</HintPath>
@@ -75,6 +77,7 @@
     <Reference Include="Physical_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Physical_oM.dll</HintPath>
       <Private>False</Private>
+	  <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Reflection_Engine">
       <SpecificVersion>False</SpecificVersion>
@@ -84,10 +87,12 @@
     <Reference Include="Reflection_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Reflection_oM.dll</HintPath>
       <Private>False</Private>
+	  <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Serialiser_Engine">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Serialiser_Engine.dll</HintPath>
       <Private>False</Private>
+      <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="Structure_Engine">
       <SpecificVersion>False</SpecificVersion>
@@ -97,6 +102,7 @@
     <Reference Include="Structure_oM">
       <HintPath>C:\ProgramData\BHoM\Assemblies\Structure_oM.dll</HintPath>
       <Private>False</Private>
+	  <SpecificVersion>False</SpecificVersion>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/GSA_Engine/Modify/SetAnalysisSettings.cs
+++ b/GSA_Engine/Modify/SetAnalysisSettings.cs
@@ -50,7 +50,10 @@ namespace BH.Engine.Adapters.GSA
         public static LoadCombination SetAnalysisSettings(this LoadCombination loadcombination, AnalysisType analysisType = AnalysisType.LinearStatic, int stage = 0, double residualForce = 1.0, double residualMoment = 1.0, bool beamSlendernessEffect = true)
         {
             if (loadcombination == null)
+            {
+                Reflection.Compute.RecordError("Loadcombination is null. Cannot assign settings.");
                 return null;
+            }
             AnalysisTaskFragment fragment = new AnalysisTaskFragment { AnalysisType = analysisType, Stage = stage, ResidualForce = residualForce, ResidualMoment = residualMoment, BeamSlendernessEffect = beamSlendernessEffect };
             LoadCombination clone = loadcombination.ShallowClone();
 

--- a/GSA_Engine/Modify/SetAnalysisSettings.cs
+++ b/GSA_Engine/Modify/SetAnalysisSettings.cs
@@ -47,7 +47,7 @@ namespace BH.Engine.Adapters.GSA
         [Input("residualMoment", "Allowed residual Moment for convergence, only used for Non-linear analysis.")]
         [Input("beamSlendernessEffect", "Reduce beam stiffness when in compression, only used for Non-linear analysis.")]
         [Output("loadCombination", "The loadcombination with set analysis type and stage.")]
-        public static LoadCombination SetAnalysisType(LoadCombination loadcombination, AnalysisType analysisType = AnalysisType.LinearStatic, int stage = 0, double residualForce = 1.0, double residualMoment = 1.0, bool beamSlendernessEffect = true)
+        public static LoadCombination SetAnalysisSettings(this LoadCombination loadcombination, AnalysisType analysisType = AnalysisType.LinearStatic, int stage = 0, double residualForce = 1.0, double residualMoment = 1.0, bool beamSlendernessEffect = true)
         {
             AnalysisTaskFragment fragment = new AnalysisTaskFragment { AnalysisType = analysisType, Stage = stage, ResidualForce = residualForce, ResidualMoment = residualMoment, BeamSlendernessEffect = beamSlendernessEffect };
             LoadCombination clone = loadcombination.ShallowClone();

--- a/GSA_Engine/Modify/SetAnalysisSettings.cs
+++ b/GSA_Engine/Modify/SetAnalysisSettings.cs
@@ -49,6 +49,8 @@ namespace BH.Engine.Adapters.GSA
         [Output("loadCombination", "The loadcombination with set analysis type and stage.")]
         public static LoadCombination SetAnalysisSettings(this LoadCombination loadcombination, AnalysisType analysisType = AnalysisType.LinearStatic, int stage = 0, double residualForce = 1.0, double residualMoment = 1.0, bool beamSlendernessEffect = true)
         {
+            if (loadcombination == null)
+                return null;
             AnalysisTaskFragment fragment = new AnalysisTaskFragment { AnalysisType = analysisType, Stage = stage, ResidualForce = residualForce, ResidualMoment = residualMoment, BeamSlendernessEffect = beamSlendernessEffect };
             LoadCombination clone = loadcombination.ShallowClone();
 

--- a/GSA_Engine/Modify/SetAnalysisType.cs
+++ b/GSA_Engine/Modify/SetAnalysisType.cs
@@ -49,7 +49,7 @@ namespace BH.Engine.Adapters.GSA
         public static LoadCombination SetAnalysisType(LoadCombination loadcombination, AnalysisType analysisType = AnalysisType.LinearStatic, int stage = 0, double residualForce = 1.0, double residualMoment = 1.0)
         {
             AnalysisTaskFragment fragment = new AnalysisTaskFragment { AnalysisType = analysisType, Stage = stage, ResidualForce = residualForce, ResidualMoment = residualMoment };
-            LoadCombination clone = loadcombination.GetShallowClone() as LoadCombination;
+            LoadCombination clone = loadcombination.ShallowClone();
 
             clone.Fragments.AddOrReplace(fragment);
             return clone;

--- a/GSA_Engine/Modify/SetAnalysisType.cs
+++ b/GSA_Engine/Modify/SetAnalysisType.cs
@@ -45,10 +45,11 @@ namespace BH.Engine.Adapters.GSA
         [Input("stage", "The stage number for the combination to be run on.")]
         [Input("residualForce", "Allowed residual Force for convergence, only used for Non-linear analysis.")]
         [Input("residualMoment", "Allowed residual Moment for convergence, only used for Non-linear analysis.")]
+        [Input("beamSlendernessEffect", "Reduce beam stiffness when in compression, only used for Non-linear analysis.")]
         [Output("loadCombination", "The loadcombination with set analysis type and stage.")]
-        public static LoadCombination SetAnalysisType(LoadCombination loadcombination, AnalysisType analysisType = AnalysisType.LinearStatic, int stage = 0, double residualForce = 1.0, double residualMoment = 1.0)
+        public static LoadCombination SetAnalysisType(LoadCombination loadcombination, AnalysisType analysisType = AnalysisType.LinearStatic, int stage = 0, double residualForce = 1.0, double residualMoment = 1.0, bool beamSlendernessEffect = true)
         {
-            AnalysisTaskFragment fragment = new AnalysisTaskFragment { AnalysisType = analysisType, Stage = stage, ResidualForce = residualForce, ResidualMoment = residualMoment };
+            AnalysisTaskFragment fragment = new AnalysisTaskFragment { AnalysisType = analysisType, Stage = stage, ResidualForce = residualForce, ResidualMoment = residualMoment, BeamSlendernessEffect = beamSlendernessEffect };
             LoadCombination clone = loadcombination.ShallowClone();
 
             clone.Fragments.AddOrReplace(fragment);

--- a/GSA_Engine/Modify/SetAnalysisType.cs
+++ b/GSA_Engine/Modify/SetAnalysisType.cs
@@ -39,14 +39,17 @@ namespace BH.Engine.Adapters.GSA
         /**** Public Methods                            ****/
         /***************************************************/
 
+        [PreviousVersion("5.0", "BH.Engine.Adapters.GSA.Modify.SetAnalysisType(BH.oM.Structure.Loads.LoadCombination, BH.oM.Adapters.GSA.AnalysisType, System.Int32)")]
         [Description("Sets the analysis type and stage for a LoadCombination")]
         [Input("loadcombination", "The load combination to set stage and analysis type for.")]
         [Input("stage", "The stage number for the combination to be run on.")]
+        [Input("residualForce", "Allowed residual Force for convergence, only used for Non-linear analysis.")]
+        [Input("residualMoment", "Allowed residual Moment for convergence, only used for Non-linear analysis.")]
         [Output("loadCombination", "The loadcombination with set analysis type and stage.")]
-        public static LoadCombination SetAnalysisType(LoadCombination loadcombination, AnalysisType analysisType = AnalysisType.LinearStatic, int stage = 0)
+        public static LoadCombination SetAnalysisType(LoadCombination loadcombination, AnalysisType analysisType = AnalysisType.LinearStatic, int stage = 0, double residualForce = 1.0, double residualMoment = 1.0)
         {
-            AnalysisTaskFragment fragment = new AnalysisTaskFragment { AnalysisType = analysisType, Stage = stage };
-            LoadCombination clone = loadcombination.ShallowClone();
+            AnalysisTaskFragment fragment = new AnalysisTaskFragment { AnalysisType = analysisType, Stage = stage, ResidualForce = residualForce, ResidualMoment = residualMoment };
+            LoadCombination clone = loadcombination.GetShallowClone() as LoadCombination;
 
             clone.Fragments.AddOrReplace(fragment);
             return clone;

--- a/GSA_oM/Fragments/AnalysisTaskFragment.cs
+++ b/GSA_oM/Fragments/AnalysisTaskFragment.cs
@@ -43,6 +43,10 @@ namespace BH.oM.Adapters.GSA
 
         [Description("Allowed residual Moment for convergence, only used for Non-linear analysis.")]
         public double ResidualMoment { get; set; } = 1.0;
+
+        [Description("Reduce beam stiffness when in compression, only used for Non-linear analysis.")]
+        public bool BeamSlendernessEffect { get; set; } = true;
+
         /***************************************************/
     }
 }

--- a/GSA_oM/Fragments/AnalysisTaskFragment.cs
+++ b/GSA_oM/Fragments/AnalysisTaskFragment.cs
@@ -38,6 +38,11 @@ namespace BH.oM.Adapters.GSA
         [Description("The stage number for the combination to be run on.")]
         public virtual int Stage { get; set; } = 0;
 
+        [Description("Allowed residual Force for convergence, only used for Non-linear analysis.")]
+        public double ResidualForce { get; set; } = 1.0;
+
+        [Description("Allowed residual Moment for convergence, only used for Non-linear analysis.")]
+        public double ResidualMoment { get; set; } = 1.0;
         /***************************************************/
     }
 }

--- a/GSA_oM/Fragments/AnalysisTaskFragment.cs
+++ b/GSA_oM/Fragments/AnalysisTaskFragment.cs
@@ -39,13 +39,13 @@ namespace BH.oM.Adapters.GSA
         public virtual int Stage { get; set; } = 0;
 
         [Description("Allowed residual Force for convergence, only used for Non-linear analysis.")]
-        public double ResidualForce { get; set; } = 1.0;
+        public virtual double ResidualForce { get; set; } = 1.0;
 
         [Description("Allowed residual Moment for convergence, only used for Non-linear analysis.")]
-        public double ResidualMoment { get; set; } = 1.0;
+        public virtual double ResidualMoment { get; set; } = 1.0;
 
         [Description("Reduce beam stiffness when in compression, only used for Non-linear analysis.")]
-        public bool BeamSlendernessEffect { get; set; } = true;
+        public virtual bool BeamSlendernessEffect { get; set; } = true;
 
         /***************************************************/
     }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #236 

 <!-- Add short description of what has been fixed -->

Adding control over:
- Resdiual force and moment for non-linear combinations
- If BeamSlendernessEffect should be taken into account for non-linear combinations

Making Cases depend on combinations so that cases are pushed in when combinations are.

 ### Test files
<!-- Link to test files to validate the proposed changes -->
Testscript pushing combinations with varied settings and also checking that pushing without fragment assigned works.

https://burohappold.sharepoint.com/:f:/s/BHoM/EgbK4bHB-kxIr4wiRKXyON8BB0tUUQZvA-k2grsaKk22gg?e=GSzSRN

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
