### PR TITLE
Assign ID to faces when pulling

### DIFF
--- a/GSA_Adapter/Convert/FromGsa/Elements/FEMesh.cs
+++ b/GSA_Adapter/Convert/FromGsa/Elements/FEMesh.cs
@@ -52,16 +52,20 @@ namespace BH.Adapter.GSA
                         continue;
                 }
 
+                int id = gsaMesh.Ref;
+
+                FEMeshFace face = new FEMeshFace() { NodeListIndices = Enumerable.Range(0, gsaMesh.NumTopo).ToList() };
+                face.SetAdapterId(typeof(GSAId), id);
+
                 FEMesh mesh = new FEMesh()
                 {
-                    Faces = new List<FEMeshFace>() { new FEMeshFace() { NodeListIndices = Enumerable.Range(0, gsaMesh.NumTopo).ToList() } },
+                    Faces = new List<FEMeshFace>() { face },
                     Nodes = gsaMesh.Topo.Select(x => nodes[x.ToString()]).ToList(),
                     Property = props[gsaMesh.Property.ToString()]
                 };
 
                 mesh.ApplyTaggedName(gsaMesh.Name);
 
-                int id = gsaMesh.Ref;
                 mesh.SetAdapterId(typeof(GSAId), id);
 
                 meshList.Add(mesh);


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #238 

 <!-- Add short description of what has been fixed -->

Load push was changed to look at ids of faces rather than the mesh. This change should have been made simultaneously, as without this change, the loads can not be pushed when using pulled FEMeshes

 ### Test files
<!-- Link to test files to validate the proposed changes -->

https://burohappold.sharepoint.com/:f:/s/BHoM/Ep2YzfY1pTBPlgeleEeDt78BVizKMSA7XCPgXqg6V-xZuA?e=zQRGvI

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
