### PR TITLE
Tweaks to get GSA ready for altconfigs in installers.

### DIFF
--- a/GSA_Adapter/AdapterActions/Execute.cs
+++ b/GSA_Adapter/AdapterActions/Execute.cs
@@ -29,9 +29,9 @@ using BH.oM.Adapter.Commands;
 namespace BH.Adapter.GSA
 {
 #if GSA_10_1
-    public partial class GSA_10_1Adapter
+    public partial class GSA101Adapter
 #elif GSA_8_7
-    public partial class GSA_8_7Adapter
+    public partial class GSA87Adapter
 #else
     public partial class GSAAdapter
 #endif

--- a/GSA_Adapter/AdapterActions/Execute.cs
+++ b/GSA_Adapter/AdapterActions/Execute.cs
@@ -30,10 +30,8 @@ namespace BH.Adapter.GSA
 {
 #if GSA_10_1
     public partial class GSA101Adapter
-#elif GSA_8_7
-    public partial class GSA87Adapter
 #else
-    public partial class GSAAdapter
+    public partial class GSA87Adapter
 #endif
     {
         /***************************************************/

--- a/GSA_Adapter/AdapterActions/Pull.cs
+++ b/GSA_Adapter/AdapterActions/Pull.cs
@@ -29,10 +29,8 @@ namespace BH.Adapter.GSA
 {
 #if GSA_10_1
     public partial class GSA101Adapter
-#elif GSA_8_7
-    public partial class GSA87Adapter
 #else
-    public partial class GSAAdapter
+    public partial class GSA87Adapter
 #endif
     {
         public override IEnumerable<object> Pull(IRequest request, PullType pullType = PullType.AdapterDefault, ActionConfig actionConfig = null)

--- a/GSA_Adapter/AdapterActions/Pull.cs
+++ b/GSA_Adapter/AdapterActions/Pull.cs
@@ -28,9 +28,9 @@ using BH.oM.Adapter;
 namespace BH.Adapter.GSA
 {
 #if GSA_10_1
-    public partial class GSA_10_1Adapter
+    public partial class GSA101Adapter
 #elif GSA_8_7
-    public partial class GSA_8_7Adapter
+    public partial class GSA87Adapter
 #else
     public partial class GSAAdapter
 #endif

--- a/GSA_Adapter/CRUD/Create.cs
+++ b/GSA_Adapter/CRUD/Create.cs
@@ -40,10 +40,8 @@ namespace BH.Adapter.GSA
 {
 #if GSA_10_1
     public partial class GSA101Adapter
-#elif GSA_8_7
+#else 
     public partial class GSA87Adapter
-#else
-    public partial class GSAAdapter
 #endif
     {
         /***************************************************/

--- a/GSA_Adapter/CRUD/Create.cs
+++ b/GSA_Adapter/CRUD/Create.cs
@@ -39,9 +39,9 @@ using BH.oM.Structure.Fragments;
 namespace BH.Adapter.GSA
 {
 #if GSA_10_1
-    public partial class GSA_10_1Adapter
+    public partial class GSA101Adapter
 #elif GSA_8_7
-    public partial class GSA_8_7Adapter
+    public partial class GSA87Adapter
 #else
     public partial class GSAAdapter
 #endif

--- a/GSA_Adapter/CRUD/Delete.cs
+++ b/GSA_Adapter/CRUD/Delete.cs
@@ -31,10 +31,8 @@ namespace BH.Adapter.GSA
 {
 #if GSA_10_1
     public partial class GSA101Adapter
-#elif GSA_8_7
-    public partial class GSA87Adapter
 #else
-    public partial class GSAAdapter
+    public partial class GSA87Adapter
 #endif
     {
         /***************************************************/

--- a/GSA_Adapter/CRUD/Delete.cs
+++ b/GSA_Adapter/CRUD/Delete.cs
@@ -30,9 +30,9 @@ using System.Linq;
 namespace BH.Adapter.GSA
 {
 #if GSA_10_1
-    public partial class GSA_10_1Adapter
+    public partial class GSA101Adapter
 #elif GSA_8_7
-    public partial class GSA_8_7Adapter
+    public partial class GSA87Adapter
 #else
     public partial class GSAAdapter
 #endif

--- a/GSA_Adapter/CRUD/Read.cs
+++ b/GSA_Adapter/CRUD/Read.cs
@@ -50,10 +50,8 @@ namespace BH.Adapter.GSA
 {
 #if GSA_10_1
     public partial class GSA101Adapter
-#elif GSA_8_7
-    public partial class GSA87Adapter
 #else
-    public partial class GSAAdapter
+    public partial class GSA87Adapter
 #endif
     {
         /***************************************************/

--- a/GSA_Adapter/CRUD/Read.cs
+++ b/GSA_Adapter/CRUD/Read.cs
@@ -49,9 +49,9 @@ using BH.Engine.Adapters.GSA;
 namespace BH.Adapter.GSA
 {
 #if GSA_10_1
-    public partial class GSA_10_1Adapter
+    public partial class GSA101Adapter
 #elif GSA_8_7
-    public partial class GSA_8_7Adapter
+    public partial class GSA87Adapter
 #else
     public partial class GSAAdapter
 #endif

--- a/GSA_Adapter/CRUD/ReadResults.cs
+++ b/GSA_Adapter/CRUD/ReadResults.cs
@@ -36,10 +36,8 @@ namespace BH.Adapter.GSA
 {
 #if GSA_10_1
     public partial class GSA101Adapter
-#elif GSA_8_7
-    public partial class GSA87Adapter
 #else
-    public partial class GSAAdapter
+    public partial class GSA87Adapter
 #endif
     {
 

--- a/GSA_Adapter/CRUD/ReadResults.cs
+++ b/GSA_Adapter/CRUD/ReadResults.cs
@@ -35,9 +35,9 @@ using BH.oM.Adapter;
 namespace BH.Adapter.GSA
 {
 #if GSA_10_1
-    public partial class GSA_10_1Adapter
+    public partial class GSA101Adapter
 #elif GSA_8_7
-    public partial class GSA_8_7Adapter
+    public partial class GSA87Adapter
 #else
     public partial class GSAAdapter
 #endif

--- a/GSA_Adapter/CRUD/ReadResultsElements.cs
+++ b/GSA_Adapter/CRUD/ReadResultsElements.cs
@@ -42,9 +42,9 @@ using BH.Engine.Adapters.GSA;
 namespace BH.Adapter.GSA
 {
 #if GSA_10_1
-    public partial class GSA_10_1Adapter
+    public partial class GSA101Adapter
 #elif GSA_8_7
-    public partial class GSA_8_7Adapter
+    public partial class GSA87Adapter
 #else
     public partial class GSAAdapter
 #endif

--- a/GSA_Adapter/CRUD/ReadResultsElements.cs
+++ b/GSA_Adapter/CRUD/ReadResultsElements.cs
@@ -43,10 +43,8 @@ namespace BH.Adapter.GSA
 {
 #if GSA_10_1
     public partial class GSA101Adapter
-#elif GSA_8_7
-    public partial class GSA87Adapter
 #else
-    public partial class GSAAdapter
+    public partial class GSA87Adapter
 #endif
     {
 

--- a/GSA_Adapter/CRUD/ReadResultsGlobal.cs
+++ b/GSA_Adapter/CRUD/ReadResultsGlobal.cs
@@ -43,9 +43,9 @@ using System.Linq;
 namespace BH.Adapter.GSA
 {
 #if GSA_10_1
-    public partial class GSA_10_1Adapter
+    public partial class GSA101Adapter
 #elif GSA_8_7
-    public partial class GSA_8_7Adapter
+    public partial class GSA87Adapter
 #else
     public partial class GSAAdapter
 #endif

--- a/GSA_Adapter/CRUD/ReadResultsGlobal.cs
+++ b/GSA_Adapter/CRUD/ReadResultsGlobal.cs
@@ -44,10 +44,8 @@ namespace BH.Adapter.GSA
 {
 #if GSA_10_1
     public partial class GSA101Adapter
-#elif GSA_8_7
-    public partial class GSA87Adapter
 #else
-    public partial class GSAAdapter
+    public partial class GSA87Adapter
 #endif
     {
 

--- a/GSA_Adapter/CRUD/Update.cs
+++ b/GSA_Adapter/CRUD/Update.cs
@@ -32,10 +32,8 @@ namespace BH.Adapter.GSA
 {
 #if GSA_10_1
     public partial class GSA101Adapter
-#elif GSA_8_7
-    public partial class GSA87Adapter
 #else
-    public partial class GSAAdapter
+    public partial class GSA87Adapter
 #endif
     {
         /***************************************************/

--- a/GSA_Adapter/CRUD/Update.cs
+++ b/GSA_Adapter/CRUD/Update.cs
@@ -31,9 +31,9 @@ using BH.Engine.Adapters.GSA;
 namespace BH.Adapter.GSA
 {
 #if GSA_10_1
-    public partial class GSA_10_1Adapter
+    public partial class GSA101Adapter
 #elif GSA_8_7
-    public partial class GSA_8_7Adapter
+    public partial class GSA87Adapter
 #else
     public partial class GSAAdapter
 #endif

--- a/GSA_Adapter/CRUD/UpdateProperty.cs
+++ b/GSA_Adapter/CRUD/UpdateProperty.cs
@@ -33,9 +33,9 @@ using BH.oM.Adapter;
 namespace BH.Adapter.GSA
 {
 #if GSA_10_1
-    public partial class GSA_10_1Adapter
+    public partial class GSA101Adapter
 #elif GSA_8_7
-    public partial class GSA_8_7Adapter
+    public partial class GSA87Adapter
 #else
     public partial class GSAAdapter
 #endif

--- a/GSA_Adapter/CRUD/UpdateProperty.cs
+++ b/GSA_Adapter/CRUD/UpdateProperty.cs
@@ -34,10 +34,8 @@ namespace BH.Adapter.GSA
 {
 #if GSA_10_1
     public partial class GSA101Adapter
-#elif GSA_8_7
-    public partial class GSA87Adapter
 #else
-    public partial class GSAAdapter
+    public partial class GSA87Adapter
 #endif
     {
         protected override int IUpdateTags(Type type, IEnumerable<object> ids, IEnumerable<HashSet<string>> newTags, ActionConfig actionConfig = null)

--- a/GSA_Adapter/GSAAdapter.cs
+++ b/GSA_Adapter/GSAAdapter.cs
@@ -46,10 +46,8 @@ namespace BH.Adapter.GSA
 {
 #if GSA_10_1
     public partial class GSA101Adapter : BHoMAdapter
-#elif GSA_8_7
-    public partial class GSA87Adapter : BHoMAdapter
 #else
-    public partial class GSAAdapter : BHoMAdapter
+    public partial class GSA87Adapter : BHoMAdapter
 #endif
     {
         /***************************************************/
@@ -58,10 +56,8 @@ namespace BH.Adapter.GSA
 
 #if GSA_10_1
         public GSA101Adapter(string filePath = "", GSAConfig gsaConfig = null, bool active = false)
-#elif GSA_8_7
-        public GSA87Adapter(string filePath = "", GSAConfig gsaConfig = null, bool active = false)
 #else
-        public GSAAdapter(string filePath = "", GSAConfig gsaConfig = null, bool active = false)
+        public GSA87Adapter(string filePath = "", GSAConfig gsaConfig = null, bool active = false)
 #endif
         {
             AdapterIdFragmentType = typeof(GSAId);

--- a/GSA_Adapter/GSAAdapter.cs
+++ b/GSA_Adapter/GSAAdapter.cs
@@ -45,9 +45,9 @@ using BH.oM.Adapters.GSA.Elements;
 namespace BH.Adapter.GSA
 {
 #if GSA_10_1
-    public partial class GSA_10_1Adapter : BHoMAdapter
+    public partial class GSA101Adapter : BHoMAdapter
 #elif GSA_8_7
-    public partial class GSA_8_7Adapter : BHoMAdapter
+    public partial class GSA87Adapter : BHoMAdapter
 #else
     public partial class GSAAdapter : BHoMAdapter
 #endif
@@ -57,9 +57,9 @@ namespace BH.Adapter.GSA
         /***************************************************/
 
 #if GSA_10_1
-        public GSA_10_1Adapter(string filePath = "", GSAConfig gsaConfig = null, bool active = false)
+        public GSA101Adapter(string filePath = "", GSAConfig gsaConfig = null, bool active = false)
 #elif GSA_8_7
-        public GSA_8_7Adapter(string filePath = "", GSAConfig gsaConfig = null, bool active = false)
+        public GSA87Adapter(string filePath = "", GSAConfig gsaConfig = null, bool active = false)
 #else
         public GSAAdapter(string filePath = "", GSAConfig gsaConfig = null, bool active = false)
 #endif

--- a/GSA_Adapter/GSA_Adapter.csproj
+++ b/GSA_Adapter/GSA_Adapter.csproj
@@ -245,6 +245,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />
+    <None Include="Versioning_60.json" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" Condition="" />
   <PropertyGroup>

--- a/GSA_Adapter/GSA_Adapter.csproj
+++ b/GSA_Adapter/GSA_Adapter.csproj
@@ -17,17 +17,19 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <DefineConstants>DEBUG;TRACE;GSA_8_7</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+	<AssemblyName>GSA87_Adapter</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>..\Build\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
+    <DefineConstants>TRACE;GSA_8_7</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+	<AssemblyName>GSA87_Adapter</AssemblyName>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug87|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>

--- a/GSA_Adapter/Types/NextId.cs
+++ b/GSA_Adapter/Types/NextId.cs
@@ -33,9 +33,9 @@ using BH.oM.Structure.MaterialFragments;
 namespace BH.Adapter.GSA
 {
 #if GSA_10_1
-    public partial class GSA_10_1Adapter
+    public partial class GSA101Adapter
 #elif GSA_8_7
-    public partial class GSA_8_7Adapter
+    public partial class GSA87Adapter
 #else
     public partial class GSAAdapter
 #endif

--- a/GSA_Adapter/Types/NextId.cs
+++ b/GSA_Adapter/Types/NextId.cs
@@ -34,10 +34,8 @@ namespace BH.Adapter.GSA
 {
 #if GSA_10_1
     public partial class GSA101Adapter
-#elif GSA_8_7
-    public partial class GSA87Adapter
 #else
-    public partial class GSAAdapter
+    public partial class GSA87Adapter
 #endif
     {
         /***************************************************/

--- a/GSA_Adapter/Versioning_60.json
+++ b/GSA_Adapter/Versioning_60.json
@@ -1,0 +1,29 @@
+﻿{
+  "Namespace": {
+    "ToNew": {
+    },
+    "ToOld": {
+    }
+  },
+  "Type": {
+    "ToNew": {
+      "BH.Adapter.GSA.GSAAdapter" : "BH.Adapter.GSA.GSA87Adapter",
+      "BH.Adapter.GSA.GSA_8_7Adapter" : "BH.Adapter.GSA.GSA87Adapter",
+      "BH.Adapter.GSA.GSA_10_1Adapter" : "BH.Adapter.GSA.GSA101Adapter"
+    },
+    "ToOld": {
+      "BH.Adapter.GSA.GSA87Adapter" : "BH.Adapter.GSA.GSAAdapter",
+      "BH.Adapter.GSA.GSA101Adapter" : "BH.Adapter.GSA.GSA_10_1Adapter"
+    }
+  },
+  "Property": {
+    "ToNew": {
+    },
+    "ToOld": {
+    }
+  },
+  "MessageForDeleted": {
+  },
+  "MessageForNoUpgrade": {
+  }
+}

--- a/altConfigs.txt
+++ b/altConfigs.txt
@@ -1,0 +1,4 @@
+Debug87
+Debug101
+Release87
+Release101


### PR DESCRIPTION
 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

Get GSA ready for inclusion in installers

Link to installer: https://burohappold.sharepoint.com/:f:/s/BHoM/EvGchF7-ctJCvjYPf76uG2ABbViKvnThhddyo4-Y-_770g?e=jNZKA4

 <!-- Add short description of what has been fixed -->

Rename GSA_10_1Adapter to GSA101Adapter to match what is done elsewhere
Rename GSA_8_7Adatper  to GSA87Adapter to match what is done elsewhere
Add versioning to accommodate the above
Add versioning from GSAAdapter -> GSA87Adapter as GSAAdapter wont be part of installers as soon as altconfigs start building. The previous the Debug build behaves as the Debug87 build (same for release) so an upgrade to GSA87Adapter should give the same behaviour for old scripts. If a script should start targeting GSA10.1, a change of adapter is required, but this should be expected as it is a new target.

 ### Test files
<!-- Link to test files to validate the proposed changes -->

Running of installers produced by installer PRs and ensuring that GSA87Adapter and GSA101Adapters exists. 
Opening old scripts with GSAAdapter present and make sure they are updated to GSA87ADapter and functions as before.
Opening old scripts with GSA_10_1Adapter making sure they are correctly versioned and functions.

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
