### PR TITLE
Make use of caching system in base adapter

### DIFF
--- a/GSA_Adapter/CRUD/Create.cs
+++ b/GSA_Adapter/CRUD/Create.cs
@@ -75,19 +75,23 @@ namespace BH.Adapter.GSA
 
         /***************************************************/
 
+#if GSA_10_1
         private bool CreateMaterials(IEnumerable<IMaterialFragment> materials)
         {
             bool success = true;
             foreach (IMaterialFragment material in materials)
             {
-                int index = m_gsaCom.GwaCommand("HIGHEST, " + Convert.ToGsaString(material.GetType())) + 1;
-                this.SetAdapterId(material, index);
+                string type = Convert.ToGsaString(material.GetType());
+                int index = m_gsaCom.GwaCommand("HIGHEST, " + type) + 1;
+                this.SetAdapterId(material, $"{type.Split('_').Last()}:{index}");
                 success &= ComCall(Convert.IToGsaString(material, index.ToString()));
             }
             return success;
         }
 
         /***************************************************/
+
+#endif
 
         private bool CreateObject(BH.oM.Base.IBHoMObject obj)
         {

--- a/GSA_Adapter/CRUD/Read.cs
+++ b/GSA_Adapter/CRUD/Read.cs
@@ -121,7 +121,7 @@ namespace BH.Adapter.GSA
             string allProps = m_gsaCom.GwaCommand("GET_ALL, MAT").ToString();
 #endif
             string[] matArr = string.IsNullOrWhiteSpace(allProps) ? new string[0] : allProps.Split('\n');
-            matArr = matArr.Where(x => !string.IsNullOrWhiteSpace(x)).ToArray();
+            matArr = matArr.Where(x => !string.IsNullOrWhiteSpace(x)).Distinct().ToArray();
 
             if (ids == null)
                 materials = matArr.Select(x => Convert.FromGsaMaterial(x)).Where(x => x != null).ToList();

--- a/GSA_Adapter/CRUD/Read.cs
+++ b/GSA_Adapter/CRUD/Read.cs
@@ -135,7 +135,11 @@ namespace BH.Adapter.GSA
 
         public Dictionary<string, IMaterialFragment> ReadMaterialDictionary(List<string> ids = null, bool includeStandard = false)
         {
+#if GSA_10_1
             Dictionary<string, IMaterialFragment> materials = GetCachedOrReadAsDictionary<string, IMaterialFragment>(ids);
+#else
+            Dictionary<string, IMaterialFragment> materials = GetCachedOrReadAsDictionary<int, IMaterialFragment>(ids?.Select(x => int.Parse(x)).ToList()).ToDictionary(x => x.Key.ToString(), x => x.Value);
+#endif
             if (includeStandard)
             {
                 foreach (IMaterialFragment standardMaterial in GetStandardGsaMaterials())

--- a/GSA_Adapter/CRUD/Update.cs
+++ b/GSA_Adapter/CRUD/Update.cs
@@ -27,6 +27,8 @@ using BH.oM.Structure.Elements;
 using BH.Engine.Adapter;
 using BH.oM.Adapters.GSA;
 using BH.Engine.Adapters.GSA;
+using BH.oM.Structure.MaterialFragments;
+using System.Linq;
 
 namespace BH.Adapter.GSA
 {
@@ -73,6 +75,19 @@ namespace BH.Adapter.GSA
         }
 
         /***************************************************/
+
+#if GSA_10_1
+        private bool Update(IEnumerable<IMaterialFragment> materials, ActionConfig actionConfig = null) 
+        {
+            bool success = true;
+            foreach (IMaterialFragment material in materials)
+            {
+                string index = this.GetAdapterId<string>(material).Split(':').FirstOrDefault();
+                success &= ComCall(Convert.IToGsaString(material, index));
+            }
+            return success;
+        }
+#endif
     }
 }
 

--- a/GSA_Adapter/CRUD/Update.cs
+++ b/GSA_Adapter/CRUD/Update.cs
@@ -82,8 +82,7 @@ namespace BH.Adapter.GSA
             bool success = true;
             foreach (IMaterialFragment material in materials)
             {
-                string index = this.GetAdapterId<string>(material).Split(':').FirstOrDefault();
-                success &= ComCall(Convert.IToGsaString(material, index));
+                success &= ComCall(Convert.IToGsaString(material, material.MaterialId()));
             }
             return success;
         }

--- a/GSA_Adapter/Convert/FromGsa/Elements/Bar.cs
+++ b/GSA_Adapter/Convert/FromGsa/Elements/Bar.cs
@@ -43,7 +43,7 @@ namespace BH.Adapter.GSA
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static List<Bar> FromGsaBars(IEnumerable<GsaElement> gsaElements, Dictionary<string, ISectionProperty> secProps, Dictionary<string, Node> nodes)
+        public static List<Bar> FromGsaBars(IEnumerable<GsaElement> gsaElements, Dictionary<int, ISectionProperty> secProps, Dictionary<int, Node> nodes)
         {
             List<Bar> barList = new List<Bar>();
 
@@ -71,8 +71,8 @@ namespace BH.Adapter.GSA
                 }
 
                 Node n1, n2;
-                nodes.TryGetValue(gsaBar.Topo[0].ToString(), out n1);
-                nodes.TryGetValue(gsaBar.Topo[1].ToString(), out n2);
+                nodes.TryGetValue(gsaBar.Topo[0], out n1);
+                nodes.TryGetValue(gsaBar.Topo[1], out n2);
 
                 Bar bar = new Bar { StartNode = n1, EndNode = n2 };
                 bar.ApplyTaggedName(gsaBar.Name);
@@ -82,7 +82,7 @@ namespace BH.Adapter.GSA
                 bar.OrientationAngle = gsaBar.Beta;
 
                 ISectionProperty prop;
-                secProps.TryGetValue(gsaBar.Property.ToString(), out prop);
+                secProps.TryGetValue(gsaBar.Property, out prop);
 
                 bar.SectionProperty = prop;
 
@@ -97,7 +97,7 @@ namespace BH.Adapter.GSA
 
         /***************************************************/
 
-        public static List<Bar> FromGsaBars(IEnumerable<string> gsaStrings, Dictionary<string, ISectionProperty> secProps, Dictionary<string, Node> nodes, List<string> ids)
+        public static List<Bar> FromGsaBars(IEnumerable<string> gsaStrings, Dictionary<int, ISectionProperty> secProps, Dictionary<int, Node> nodes, List<string> ids)
         {
             List<Bar> barList = new List<Bar>();
 
@@ -135,15 +135,15 @@ namespace BH.Adapter.GSA
 
                 Bar bar = new Bar()
                 {
-                    StartNode = nodes[arr[7]],
-                    EndNode = nodes[arr[8]],
+                    StartNode = nodes[int.Parse(arr[7])],
+                    EndNode = nodes[int.Parse(arr[8])],
                     FEAType = feType,
                 };
 
                 bar.ApplyTaggedName(arr[2]);
 
                 ISectionProperty prop;
-                if (secProps.TryGetValue(arr[5], out prop))
+                if (secProps.TryGetValue(int.Parse(arr[5]), out prop))
                     bar.SectionProperty = prop;
 
                 if (arr.Length > 10)

--- a/GSA_Adapter/Convert/FromGsa/Elements/FEMesh.cs
+++ b/GSA_Adapter/Convert/FromGsa/Elements/FEMesh.cs
@@ -41,7 +41,7 @@ namespace BH.Adapter.GSA
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static List<FEMesh> FromGsaFEMesh(IEnumerable<GsaElement> gsaElements, Dictionary<string, ISurfaceProperty> props, Dictionary<string, Node> nodes)
+        public static List<FEMesh> FromGsaFEMesh(IEnumerable<GsaElement> gsaElements, Dictionary<int, ISurfaceProperty> props, Dictionary<int, Node> nodes)
         {
             List<FEMesh> meshList = new List<FEMesh>();
 
@@ -61,12 +61,12 @@ namespace BH.Adapter.GSA
                 FEMeshFace face = new FEMeshFace() { NodeListIndices = Enumerable.Range(0, gsaMesh.NumTopo).ToList(), OrientationAngle = gsaMesh.Beta * System.Math.PI / 180  };
                 face.SetAdapterId(typeof(GSAId), id);
                 ISurfaceProperty property;
-                props.TryGetValue(gsaMesh.Property.ToString(), out property);
+                props.TryGetValue(gsaMesh.Property, out property);
 
                 FEMesh mesh = new FEMesh()
                 {
                     Faces = new List<FEMeshFace>() { face },
-                    Nodes = gsaMesh.Topo.Select(x => nodes[x.ToString()]).ToList(),
+                    Nodes = gsaMesh.Topo.Select(x => nodes[x]).ToList(),
                     Property = property
                 };
 

--- a/GSA_Adapter/Convert/FromGsa/Elements/RigidLink.cs
+++ b/GSA_Adapter/Convert/FromGsa/Elements/RigidLink.cs
@@ -41,7 +41,7 @@ namespace BH.Adapter.GSA
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static List<RigidLink> FromGsaRigidLinks(IEnumerable<GsaElement> gsaElements, Dictionary<string, LinkConstraint> constraints, Dictionary<string, Node> nodes)
+        public static List<RigidLink> FromGsaRigidLinks(IEnumerable<GsaElement> gsaElements, Dictionary<int, LinkConstraint> constraints, Dictionary<int, Node> nodes)
         {
             List<RigidLink> linkList = new List<RigidLink>();
 
@@ -50,17 +50,17 @@ namespace BH.Adapter.GSA
                 if (gsaLink.eType != 9)
                     continue;
 
-                RigidLink face = new RigidLink()
+                RigidLink link = new RigidLink()
                 {
-                    PrimaryNode = nodes[gsaLink.Topo[0].ToString()],
-                    SecondaryNodes = new List<Node> { nodes[gsaLink.Topo[1].ToString()] },
-                    Constraint = constraints[gsaLink.Property.ToString()]
+                    PrimaryNode = nodes[gsaLink.Topo[0]],
+                    SecondaryNodes = new List<Node> { nodes[gsaLink.Topo[1]] },
+                    Constraint = constraints[gsaLink.Property]
                 };
 
-                face.ApplyTaggedName(gsaLink.Name);
+                link.ApplyTaggedName(gsaLink.Name);
                 int id = gsaLink.Ref;
-                face.SetAdapterId(typeof(GSAId), id);
-                linkList.Add(face);
+                link.SetAdapterId(typeof(GSAId), id);
+                linkList.Add(link);
 
             }
             return linkList;

--- a/GSA_Adapter/Convert/FromGsa/Elements/Spacer.cs
+++ b/GSA_Adapter/Convert/FromGsa/Elements/Spacer.cs
@@ -46,7 +46,7 @@ namespace BH.Adapter.GSA
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static List<Spacer> FromGsaSpacers(IEnumerable<GsaElement> gsaElements, Dictionary<string, SpacerProperty> spaProps, Dictionary<string, Node> nodes)
+        public static List<Spacer> FromGsaSpacers(IEnumerable<GsaElement> gsaElements, Dictionary<int, SpacerProperty> spaProps, Dictionary<int, Node> nodes)
         {
             List<Spacer> spacerList = new List<Spacer>();
 
@@ -56,16 +56,14 @@ namespace BH.Adapter.GSA
                     continue;
 
                 Node n1, n2;
-                nodes.TryGetValue(gsaSpacer.Topo[0].ToString(), out n1);
-                nodes.TryGetValue(gsaSpacer.Topo[1].ToString(), out n2);
+                nodes.TryGetValue(gsaSpacer.Topo[0], out n1);
+                nodes.TryGetValue(gsaSpacer.Topo[1], out n2);
 
                 Spacer spacer = new Spacer { StartNode = n1, EndNode = n2 };
                 spacer.ApplyTaggedName(gsaSpacer.Name);
 
-
-
-               SpacerProperty prop;
-               spaProps.TryGetValue(gsaSpacer.Property.ToString(), out prop);
+                SpacerProperty prop;
+                spaProps.TryGetValue(gsaSpacer.Property, out prop);
 
                 spacer.SpacerProperty = prop;
 

--- a/GSA_Adapter/Convert/FromGsa/Loads/LoadCombination.cs
+++ b/GSA_Adapter/Convert/FromGsa/Loads/LoadCombination.cs
@@ -36,7 +36,7 @@ namespace BH.Adapter.GSA
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static LoadCombination FromGsaAnalTask(string gsaString, Dictionary<string, Loadcase> lCases)
+        public static LoadCombination FromGsaAnalTask(string gsaString, Dictionary<int, Loadcase> lCases)
         {
 
             if (string.IsNullOrWhiteSpace(gsaString))
@@ -61,7 +61,7 @@ namespace BH.Adapter.GSA
                         lCaseParam[0] = "1.0";
 
                     Loadcase templCase;
-                    if (!lCases.TryGetValue(lCaseParam[1], out templCase))
+                    if (!lCases.TryGetValue(int.Parse(lCaseParam[1]), out templCase))
                     {
                         templCase = new Loadcase { Number = int.Parse(lCaseParam[1]), Nature = LoadNature.Other };
                         templCase.SetAdapterId(typeof(GSAId), templCase.Number);

--- a/GSA_Adapter/Convert/FromGsa/Properties/Material.cs
+++ b/GSA_Adapter/Convert/FromGsa/Properties/Material.cs
@@ -116,7 +116,12 @@ namespace BH.Adapter.GSA
                 return null;
             }
 
-            int id = int.Parse(gStr[1]);
+            string id = gStr[1];
+
+#if GSA_10_1
+            id = gsaString.Split(("_.").ToCharArray())[1] + ":" + id;
+#endif
+
             mat.SetAdapterId(typeof(GSAId),id);
 
             return mat;

--- a/GSA_Adapter/Convert/FromGsa/Properties/Material.cs
+++ b/GSA_Adapter/Convert/FromGsa/Properties/Material.cs
@@ -116,14 +116,16 @@ namespace BH.Adapter.GSA
                 return null;
             }
 
-            string id = gStr[1];
+
 
 #if GSA_10_1
+            string id = gStr[1];
             id = gsaString.Split(("_.").ToCharArray())[1] + ":" + id;
+            mat.SetAdapterId(typeof(GSAId), id);
+#else
+            int id = int.Parse(gStr[1]);
+            mat.SetAdapterId(typeof(GSAId), id);
 #endif
-
-            mat.SetAdapterId(typeof(GSAId),id);
-
             return mat;
         }
 

--- a/GSA_Adapter/Convert/ToGsa/Properties/Material.cs
+++ b/GSA_Adapter/Convert/ToGsa/Properties/Material.cs
@@ -211,16 +211,28 @@ return str;
 
             if (material.GetMaterialType() == "UNDEF" || material is Aluminium)   //Aluminium current unsuported in the GSA API
             {
-                analNum = material.GSAId().ToString();
+                analNum = material.MaterialId();
             }
             else
             {
-                matNum = material.GSAId().ToString();
+                matNum = material.MaterialId();
                 materialType = material.GetMaterialType();
             }
         }
 
+        /***************************************************/
+
 #endif
+        public static string MaterialId(this IMaterialFragment material)
+        {
+#if GSA_10_1
+            return material.AdapterId<string>(typeof(GSAId)).Split(':').Last();
+#else
+            return material.GSAId().ToString();
+#endif
+        }
+
+        /***************************************************/
 
         private static string CommaSeparatedValues(Vector v)
         {
@@ -238,8 +250,10 @@ return str;
                 return "CONCRETE";
             else if (material is Aluminium)
                 return "ALUMINIUM";
-            else if (material is Timber)
-                return "TIMBER";
+            else if (material is Fabric)
+                return "FABRIC";
+            //else if (material is Timber)
+            //    return "TIMBER";
             else
                 return "UNDEF";
 #else

--- a/GSA_Adapter/Convert/ToGsa/Properties/SectionProperty.cs
+++ b/GSA_Adapter/Convert/ToGsa/Properties/SectionProperty.cs
@@ -60,8 +60,6 @@ namespace BH.Adapter.GSA
             prop.Name = prop.DescriptionOrName().ToGSACleanName();
             string name = prop.TaggedName();
 
-            string mat = prop.Material.GSAId().ToString();// materialId;  //"STEEL";// material.Name;
-
             string colour = "NO_RGB";
             string principle = "NO";
             string type = prop.SectionType();
@@ -81,6 +79,7 @@ namespace BH.Adapter.GSA
             //SECTION.7 | ref | colour | name | memb | pool | point | refY | refZ | mass | fraction | cost | left | right | slab | num { <comp> }
             string str = "SECTION.7," + index + "," + colour + "," + name + ",1D_GENERIC,0,CENTROID,0,0,0,1,0,0,0,0,1," + sectionComp + "," + prop.ISectionMaterialComp();
 #else
+            string mat = prop.Material.GSAId().ToString();// materialId;  //"STEEL";// material.Name;
             string str = "PROP_SEC" + "," + index + "," + name + "," + colour + "," + mat + "," + description + "," + principle + "," + type + "," + cost + "," + props + "," + mods + "," + plate_type + "," + calc_J;
 #endif
             return str;

--- a/GSA_Adapter/Convert/ToGsa/Properties/SurfaceProperties.cs
+++ b/GSA_Adapter/Convert/ToGsa/Properties/SurfaceProperties.cs
@@ -46,7 +46,6 @@ namespace BH.Adapter.GSA
         {
             panProp.Name = panProp.DescriptionOrName().ToGSACleanName();
             string name = panProp.TaggedName();
-            string mat = panProp.Material.GSAId().ToString();
 
             string command = "PROP_2D";
             string colour = "NO_RGB";
@@ -83,6 +82,7 @@ namespace BH.Adapter.GSA
             //PROP_2D.7 | num | name | colour | type | axis | mat | mat_type | grade | design | profile | ref_pt | ref_z | mass | flex | shear | inplane | weight |
             return $"PROP_2D.7, {index}, {name}, {colour}, {type}, {axis}, {analNum}, {materialType}, {matNum}, {design}, {thick}, {ref_pt}, {ref_z}, {mass}, {bending}, {shear}, {inplane}, {weight}";
 #else
+            string mat = panProp.Material.GSAId().ToString();
             return command + "," + index + "," + name + "," + colour + "," + axis + "," + mat + "," + type + "," + thick + "," + weight + "," + mass + "," + bending + "," + inplane;
 #endif
         }
@@ -119,7 +119,7 @@ namespace BH.Adapter.GSA
             string name = panProp.TaggedName();
             string colour = "NO_RGB";
             string axis = "GLOBAL";
-            string mat = panProp.Material.GSAId().ToString();
+            string mat = panProp.Material.MaterialId();
             string type = "FABRIC";
             string thick = "0.1";
             string mass = panProp.AdditionalMass.ToString();

--- a/GSA_Adapter/Convert/ToGsa/_ToGsa.cs
+++ b/GSA_Adapter/Convert/ToGsa/_ToGsa.cs
@@ -34,7 +34,7 @@ using System.ComponentModel;
 using BH.oM.Adapters.GSA.SpacerProperties;
 using BH.oM.Adapters.GSA.Elements;
 using BH.oM.Base.Attributes;
-
+using BH.oM.Adapters.GSA.MaterialFragments;
 
 namespace BH.Adapter.GSA
 {
@@ -56,9 +56,11 @@ namespace BH.Adapter.GSA
             else if (type == typeof(Concrete))
                 return "MAT_CONCRETE";
             else if (type == typeof(Timber))
-                return "MAT_TIMBER";
+                return "MAT_ANAL";//return "MAT_TIMBER";
             else if (type == typeof(Aluminium))
-                return "MAT_ALUMINIUM";
+                return "MAT_ANAL";//return "MAT_ALUMINIUM";
+            else if (type == typeof(Fabric))
+                return "MAT_FABRIC";//return "MAT_ALUMINIUM";
             else if (type == typeof(GenericIsotropicMaterial) || type == typeof(GenericOrthotropicMaterial))
                 return "MAT_ANAL";
 #else


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->

https://github.com/BHoM/BHoM_Adapter/pull/337
intentionally using different branch names to let the Adapter PR be merged separately.

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #276

 <!-- Add short description of what has been fixed -->

Make use of the Caching system added to the Base adapter. Aim for this to speed up the push process, especially for higher level objects.

Also includes a tweak to read of materials to aim to make it fit with new system. ID for materials for GSA10 now includes material type, as that is required to differentiate between different material types

Had to change some dictionaries to int keys instead of string to align with the actual adapter ids, which lead to having to make minor updates to some convert methods. Also fixed some minor copy-paste typos.

 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
