### PR TITLE
Read load combination with parantheses

### DIFF
--- a/GSA_Adapter/Convert/FromGsa/Loads/LoadCombination.cs
+++ b/GSA_Adapter/Convert/FromGsa/Loads/LoadCombination.cs
@@ -46,7 +46,7 @@ namespace BH.Adapter.GSA
 
             if (gStr[4].Contains("("))
             {
-                Char[] separator = { '(', ')' };
+                Char[] separators = { '(', ')' };
                 string[] splitString = gStr[4].Split(separator);
 
                 string newString = "";

--- a/GSA_Adapter/Convert/FromGsa/Loads/LoadCombination.cs
+++ b/GSA_Adapter/Convert/FromGsa/Loads/LoadCombination.cs
@@ -44,7 +44,6 @@ namespace BH.Adapter.GSA
             List<Tuple<double, ICase>> lCasesForTask = new List<Tuple<double, ICase>>();
             string[] gStr = gsaString.Split(',');
 
-
             if (gStr[4].Contains("("))
             {
                 Char[] separator = { '(', ')' };

--- a/GSA_Adapter/Convert/FromGsa/Loads/LoadCombination.cs
+++ b/GSA_Adapter/Convert/FromGsa/Loads/LoadCombination.cs
@@ -47,7 +47,7 @@ namespace BH.Adapter.GSA
             if (gStr[4].Contains("("))
             {
                 Char[] separators = { '(', ')' };
-                string[] splitString = gStr[4].Split(separator);
+                string[] splitString = gStr[4].Split(separators);
 
                 string newString = "";
 

--- a/GSA_Adapter/Convert/FromGsa/Loads/LoadCombination.cs
+++ b/GSA_Adapter/Convert/FromGsa/Loads/LoadCombination.cs
@@ -27,7 +27,6 @@ using BH.Engine.Adapter;
 using BH.oM.Adapters.GSA;
 using System.Collections.Generic;
 
-
 namespace BH.Adapter.GSA
 {
     public static partial class Convert
@@ -44,6 +43,41 @@ namespace BH.Adapter.GSA
 
             List<Tuple<double, ICase>> lCasesForTask = new List<Tuple<double, ICase>>();
             string[] gStr = gsaString.Split(',');
+
+
+            if (gStr[4].Contains("("))
+            {
+                Char[] separator = { '(', ')' };
+                string[] splitString = gStr[4].Split(separator);
+
+                string newString = "";
+
+                for (int i = 1; i < splitString.Length; i += 2)
+                {
+                    string[] preString = splitString[i - 1].Split('+');
+                    string paranthesisFactor = preString[preString.Length - 1];
+                    string cleanParanthesisFactor = paranthesisFactor.Replace(" ", "");
+
+                    for (int j = 0; j < preString.Length - 1; j++)
+                    {
+                        string cleanStr = preString[j].Replace(" ", "");
+                        newString = string.Concat(newString, cleanStr, " + ");
+                    }
+
+                    string[] paranthesisCases = splitString[i].Split('+');
+
+                    for (int k = 0; k < paranthesisCases.Length - 1; k++)
+                    {
+                        string cleanParanthesisCase = paranthesisCases[k].Replace(" ", "");
+                        newString = string.Concat(newString, cleanParanthesisFactor, cleanParanthesisCase, " + ");
+                    }
+
+                    string cleanLastParanthesisCase = paranthesisCases[paranthesisCases.Length - 1].Replace(" ", "");
+                    newString = string.Concat(newString, cleanParanthesisFactor, cleanLastParanthesisCase);
+                }
+                gStr[4] = newString;
+            }
+
             string[] lCaseArr = gStr[4].Split('+');
 
             if (gStr.Length < 5)


### PR DESCRIPTION
Added if statement that replaces for example "1.5(L1 + L2)" with "1.5L1 + 1.5L2" when reading load combinations. There is probably a cleverer way of coding this?!

Please check that this works if you open the model in GSA 10.1 too.

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #282

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/GSA_Toolkit/%23283-Read-load-combinations-with-parantheses?csf=1&web=1&e=oeKcYD

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
