### PR TITLE
Changed which enum UnitType to use for NodeDisplacements

### DIFF
--- a/GSA_Adapter/CRUD/ReadResultsElements.cs
+++ b/GSA_Adapter/CRUD/ReadResultsElements.cs
@@ -201,7 +201,7 @@ namespace BH.Adapter.GSA
                 case NodeResultType.NodeDisplacement:
                     converter = Convert.FromGsaNodeDisplacement;
                     header = ResHeader.REF_DISP;
-                    unitFactor = unitFactors[(int)UnitType.LENGTH];
+                    unitFactor = unitFactors[(int)UnitType.DISP];
                     break;
                 case NodeResultType.NodeVelocity:
                 case NodeResultType.NodeAcceleration:


### PR DESCRIPTION
Changed from length to disp.

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #289 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->


 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
