### PR TITLE
Fixed CAT section bar pull errors

### DIFF
--- a/GSA_Adapter/Convert/FromGsa/Properties/SectionProperty.cs
+++ b/GSA_Adapter/Convert/FromGsa/Properties/SectionProperty.cs
@@ -126,21 +126,21 @@ namespace BH.Adapter.GSA
                         secName = secName.TrimEnd((".0").ToCharArray());
                         if (desc[1].Contains("CHS"))
                         {
-                            description = "STD%" + secType + "%";
+                            description = "STD" + splitChar + secType + splitChar;
                             string trim = desc[2].TrimStart(secType.ToCharArray());
                             string[] arr = trim.Split('x');
 
-                            description += arr[0] + "%" + arr[1];
+                            description += arr[0] + splitChar + arr[1];
 
                             Engine.Base.Compute.RecordNote("Section of type: " + secName + " not found in the library. Custom section will be used");
                         }
                         else if (desc[1].Contains("RHS"))
                         {
-                            description = "STD%" + secType + "%";
+                            description = "STD" + splitChar + secType + splitChar;
                             string trim = desc[2].TrimStart(secType.ToCharArray());
                             string[] arr = trim.Split('x');
 
-                            description += arr[0] + "%" + arr[1] + "%" + arr[2] + "%" + arr[2];
+                            description += arr[0] + splitChar + arr[1] + splitChar + arr[2] + splitChar + arr[2];
 
                             Engine.Base.Compute.RecordNote("Section of type: " + secName + " not found in the library. Custom section will be used");
                         }

--- a/GSA_Adapter/Convert/FromGsa/Properties/SectionProperty.cs
+++ b/GSA_Adapter/Convert/FromGsa/Properties/SectionProperty.cs
@@ -124,7 +124,17 @@ namespace BH.Adapter.GSA
                     else
                     {
                         secName = secName.TrimEnd((".0").ToCharArray());
-                        if (desc[1].Contains("RHS") || desc[1].Contains("CHS"))
+                        if (desc[1].Contains("CHS"))
+                        {
+                            description = "STD%" + secType + "%";
+                            string trim = desc[2].TrimStart(secType.ToCharArray());
+                            string[] arr = trim.Split('x');
+
+                            description += arr[0] + "%" + arr[1];
+
+                            Engine.Base.Compute.RecordNote("Section of type: " + secName + " not found in the library. Custom section will be used");
+                        }
+                        else if (desc[1].Contains("RHS"))
                         {
                             description = "STD%" + secType + "%";
                             string trim = desc[2].TrimStart(secType.ToCharArray());


### PR DESCRIPTION
Fixed bug where bars with CAT CHS sections couldn't be pulled from GSA because it expected an array with more items. Separated IF clause for CHS and RHS fixed it. CHS only has diameter and thickness while RHS has height, width, thickness. Results in different arrays.

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #264 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/GSA_Toolkit/%23293-CAT%20section%20pull%20errors?csf=1&web=1&e=qBkOOh

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
