### PR TITLE
Added pull BarPrestressLoad functionality

### DIFF
--- a/GSA_Adapter/Convert/FromGsa/Loads/BarPrestressLoad.cs
+++ b/GSA_Adapter/Convert/FromGsa/Loads/BarPrestressLoad.cs
@@ -1,0 +1,121 @@
+/*
+ * This file is part of the Buildings and Habitats object Model (BHoM)
+ * Copyright (c) 2015 - 2023, the respective contributors. All rights reserved.
+ *
+ * Each contributor holds copyright over their respective contributions.
+ * The project versioning (Git) records all such contribution source information.
+ *                                           
+ *                                                                              
+ * The BHoM is free software: you can redistribute it and/or modify         
+ * it under the terms of the GNU Lesser General Public License as published by  
+ * the Free Software Foundation, either version 3.0 of the License, or          
+ * (at your option) any later version.                                          
+ *                                                                              
+ * The BHoM is distributed in the hope that it will be useful,              
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of               
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the                 
+ * GNU Lesser General Public License for more details.                          
+ *                                                                            
+ * You should have received a copy of the GNU Lesser General Public License     
+ * along with this code. If not, see <https://www.gnu.org/licenses/lgpl-3.0.html>.      
+ */
+
+
+using BH.oM.Structure.Loads;
+using System;
+using BH.Engine.Adapter;
+using BH.oM.Adapters.GSA;
+using System.Collections.Generic;
+using BH.oM.Structure.Elements;
+using BH.oM.Geometry;
+using BH.oM.Base;
+using System.Linq;
+
+namespace BH.Adapter.GSA
+{
+    public static partial class Convert
+    {
+        /***************************************************/
+        /**** Public Methods                            ****/
+        /***************************************************/
+
+        public static BarPrestressLoad FromGsaBarPrestressLoad(string gsaString, Dictionary<int, Loadcase> lCases, Dictionary<int, Bar> bars, double unitFactor)
+        {
+            if (string.IsNullOrWhiteSpace(gsaString))
+                return null;
+
+            //Example gsaString: "LOAD_BEAM_PRE,,beam list,load case no,force"
+
+            string[] gStr = gsaString.Split(',');
+
+            if (gStr.Length < 4)
+                return null;
+
+            int lCaseNo = int.Parse(gStr[3]);
+
+            Loadcase loadCase;
+            if (!lCases.TryGetValue(lCaseNo, out loadCase))
+            {
+                loadCase = new Loadcase { Number = lCaseNo, Nature = LoadNature.Other };
+                loadCase.SetAdapterId(typeof(GSAId), lCaseNo);
+            }
+
+            string[] barNos = gStr[2].Split(' ');
+            string barNosClean = barNos[0];
+            for (int i = 1; i < barNos.Length; i++)
+            {
+                string addNo = barNos[i];
+                if(barNos[i] == "to")
+                {
+                    addNo = "";
+                    int range = int.Parse(barNos[i + 1]) - int.Parse(barNos[i - 1]);
+                    for (int j = 1; j < range; j++)
+                    {
+                        int number = int.Parse(barNos[i - 1]) + j;
+                        addNo = addNo + " " + number.ToString();
+                    }
+                }
+
+                barNosClean = barNosClean + " " + addNo;
+            }
+
+            string[] barNosCleanArray = barNosClean.Split(' ');
+
+            BHoMGroup<Bar> barGroup = new BHoMGroup<Bar>();
+
+            for (int i = 0; i < barNosCleanArray.Length; i++)
+            {
+                string cleanStr = barNosCleanArray[i].Replace(" ", "");
+                if (!string.IsNullOrEmpty(cleanStr))
+                {
+                    Bar bar;
+                    if (!bars.TryGetValue(int.Parse(cleanStr), out bar))
+                    {
+                        bar = new Bar();
+                        bar.SetAdapterId(typeof(GSAId), int.Parse(cleanStr));
+                    }
+                    barGroup.Elements.Add(bar);
+                }
+            }
+     
+            double prestressForce = double.Parse(gStr[4]) / unitFactor;
+
+            LoadAxis axis = LoadAxis.Global;
+            if (gStr[4] == "LOCAL")
+                axis = LoadAxis.Local;
+
+            BarPrestressLoad barPrestressLoad = new BarPrestressLoad
+            {
+                Prestress = prestressForce,
+                Loadcase = loadCase,
+                Objects = barGroup,
+                Axis = axis,
+                Projected = false
+            };
+
+            return barPrestressLoad;
+        }
+    }
+}
+
+

--- a/GSA_Adapter/GSA_Adapter.csproj
+++ b/GSA_Adapter/GSA_Adapter.csproj
@@ -186,6 +186,7 @@
     <Compile Include="Convert\FromGsa\Elements\FEMesh.cs" />
     <Compile Include="Convert\FromGsa\Elements\Spacer.cs" />
     <Compile Include="Convert\FromGsa\Loads\NodeLoad.cs" />
+    <Compile Include="Convert\FromGsa\Loads\BarPrestressLoad.cs" />
     <Compile Include="Convert\FromGsa\Properties\FormFindingProperties.cs" />
     <Compile Include="Convert\FromGsa\Properties\SpacerProperty.cs" />
     <Compile Include="Convert\FromGsa\Properties\LinkConstraint.cs" />


### PR DESCRIPTION
Functionality to pull lack of fit and initial strain will be added separately.

Could be tidied up to get the associated bars in a separate method to reuse on other pull load methods.

<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #97 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/GSA_Toolkit/%23300-Read-BarPrestressLoad?csf=1&web=1&e=weygNH

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
