### PR TITLE
Add fallback method for ToGsaString and CreateObject

### DIFF
--- a/GSA_Adapter/CRUD/Create.cs
+++ b/GSA_Adapter/CRUD/Create.cs
@@ -300,7 +300,7 @@ namespace BH.Adapter.GSA
 
         private bool CreateObject(BHoMObject obj)
         {
-            Compute.RecordError($"{obj.GetType()} is not implemented for GSA_Toolkit.");
+            Compute.RecordError($"Pushing object of type {obj.GetType()} is not implemented for GSA_Toolkit.");
             return false;
         }
 

--- a/GSA_Adapter/CRUD/Create.cs
+++ b/GSA_Adapter/CRUD/Create.cs
@@ -134,13 +134,13 @@ namespace BH.Adapter.GSA
                         success = false;
                 }
 #else
-                
+
                 if (success)
                     return true;
 #endif
             }
 
-            if(!success)
+            if (!success)
                 success = ComCall(Convert.IToGsaString(prop, GetAdapterId<int>(prop).ToString()));
 
 #if GSA_10_1
@@ -211,7 +211,7 @@ namespace BH.Adapter.GSA
 
             for (int i = 0; i < mesh.Faces.Count; i++)
             {
-                success &= ComCall(Convert.ToGsaString(mesh,id,i));
+                success &= ComCall(Convert.ToGsaString(mesh, id, i));
                 allIds.Add(id);
                 id++;
             }
@@ -250,7 +250,8 @@ namespace BH.Adapter.GSA
 
             foreach (string gsaString in load.IToGsaString(unitFactors))
             {
-                success &= ComCall(gsaString);
+                if (gsaString != "")
+                    success &= ComCall(gsaString);
             }
 
             SetAdapterId(load, load.Name ?? "");
@@ -292,6 +293,16 @@ namespace BH.Adapter.GSA
             return success;
         }
 
+
+        /***************************************************/
+        /**** Fallback  Method                         ****/
+        /***************************************************/
+
+        private bool CreateObject(BHoMObject obj)
+        {
+            Compute.RecordError($"{obj.GetType()} is not implemented for GSA_Toolkit.");
+            return false;
+        }
 
         /***************************************************/
 

--- a/GSA_Adapter/CRUD/Create.cs
+++ b/GSA_Adapter/CRUD/Create.cs
@@ -295,16 +295,6 @@ namespace BH.Adapter.GSA
 
 
         /***************************************************/
-        /**** Fallback  Method                         ****/
-        /***************************************************/
-
-        private bool CreateObject(BHoMObject obj)
-        {
-            Compute.RecordError($"Pushing object of type {obj.GetType()} is not implemented for GSA_Toolkit.");
-            return false;
-        }
-
-        /***************************************************/
 
     }
 }

--- a/GSA_Adapter/Convert/ToGsa/Loads/AreaLoads.cs
+++ b/GSA_Adapter/Convert/ToGsa/Loads/AreaLoads.cs
@@ -27,6 +27,8 @@ using System.Collections.Generic;
 using System.Linq;
 using BH.Engine.Adapters.GSA;
 using BH.oM.Base;
+using System.Runtime.Remoting.Messaging;
+using System.Runtime.InteropServices;
 
 
 namespace BH.Adapter.GSA
@@ -39,12 +41,13 @@ namespace BH.Adapter.GSA
 
         public static List<string> ToGsaString(this IElementLoad<IAreaElement> areaLoad, double[] unitFactors)
         {
-            List<string> forceStrings = new List<string>();
+            double factor = areaLoad.IFactor(unitFactors);
+            if(double.IsNaN(factor))
+                return new List<string>();
 
             string name = areaLoad.Name;
             string projection = areaLoad.IsProjectedString();
             string axis = areaLoad.IsGlobal();
-            double factor = areaLoad.IFactor(unitFactors);
             string appliedTo = areaLoad.CreateIdListOrGroupNameAreaLoad();
             Vector[] force = { areaLoad.ITranslationVector()[0], areaLoad.ITranslationVector()[1] };
             string caseNo = areaLoad.Loadcase.Number.ToString();
@@ -56,6 +59,7 @@ namespace BH.Adapter.GSA
 
             string str = command + "," + name + "," + appliedTo + "," + caseNo + "," + axis + "," + type + "," + projection;
 
+            List<string> forceStrings = new List<string>();
             VectorDataToString(str, force, ref forceStrings, factor, true, pos);
 
             return forceStrings;

--- a/GSA_Adapter/Convert/ToGsa/Loads/BarLoads.cs
+++ b/GSA_Adapter/Convert/ToGsa/Loads/BarLoads.cs
@@ -38,12 +38,14 @@ namespace BH.Adapter.GSA
 
         public static List<string> ToGsaString(this IElementLoad<Bar> barLoad, double[] unitFactors)
         {
-            List<string> forceStrings = new List<string>();
+            double factor = barLoad.IFactor(unitFactors);
+            if (double.IsNaN(factor))
+                return new List<string>();
 
             string name = barLoad.Name;
             string projection = barLoad.IsProjectedString();
             string axis = barLoad.IsGlobal();
-            double factor = barLoad.IFactor(unitFactors);
+
             string appliedTo = barLoad.CreateIdListOrGroupName();
             Vector[] force = { barLoad.ITranslationVector()[0], barLoad.ITranslationVector()[1] };
             Vector[] moment = { barLoad.IRotationVector()[0], barLoad.IRotationVector()[1] };
@@ -59,6 +61,7 @@ namespace BH.Adapter.GSA
 
             string str = command + "," + name + "," + appliedTo + "," + caseNo + "," + axis + "," + projection;
 
+            List<string> forceStrings = new List<string>();
             VectorDataToString(str, force, ref forceStrings, factor, true, pos);
             VectorDataToString(str, moment, ref forceStrings, factor, false, pos);
 

--- a/GSA_Adapter/Convert/ToGsa/Loads/Factor.cs
+++ b/GSA_Adapter/Convert/ToGsa/Loads/Factor.cs
@@ -78,6 +78,16 @@ namespace BH.Adapter.GSA
         //}
 
         /***************************************************/
+        /**** Private Methods - Fallback                ****/
+        /***************************************************/
+
+        private static double Factor(this ILoad load, double[] unitType)
+        {
+            NotSupportedWarning(load.GetType(), "Loads");
+            return double.NaN;
+        }
+
+        /***************************************************/
         /**** private Methods - Interfaces              ****/
         /***************************************************/
 

--- a/GSA_Adapter/Convert/ToGsa/Loads/Load.cs
+++ b/GSA_Adapter/Convert/ToGsa/Loads/Load.cs
@@ -68,7 +68,7 @@ namespace BH.Adapter.GSA
 
         private static List<string> ToGsaString(this ILoad load, double[] unitFactors)
         {
-            Engine.Base.Compute.RecordError($"Pushing load of type {load.GetType()} is not implemented for GSA_Toolkit.");
+            NotSupportedWarning(load.GetType(), "Loads");
             return new List<string>();
         }
 

--- a/GSA_Adapter/Convert/ToGsa/Loads/Load.cs
+++ b/GSA_Adapter/Convert/ToGsa/Loads/Load.cs
@@ -22,8 +22,15 @@
 
 
 using BH.oM.Structure.Loads;
+using BH.oM.Structure.MaterialFragments;
 using System.Collections.Generic;
 
+using BH.oM.Base;
+using BH.oM.Base.Attributes;
+using BH.oM.Geometry;
+using System;
+using System.ComponentModel;
+using System.Linq;
 
 namespace BH.Adapter.GSA
 {
@@ -55,6 +62,18 @@ namespace BH.Adapter.GSA
             return forceStrings;
         }
 
+        /***************************************************/
+        /**** Fallback  Method                         ****/
+        /***************************************************/
+
+        public static List<string> ToGsaString(this ILoad load, double[] unitFactors)
+        {
+            Engine.Base.Compute.RecordError($"{load.GetType()} is not implemented for GSA_Toolkit.");
+            return new List<string>();
+        }
+
+        /***************************************************/
+        /**** Interface  Method                         ****/
         /***************************************************/
 
         public static List<string> IToGsaString(this ILoad load, double[] unitFactors)

--- a/GSA_Adapter/Convert/ToGsa/Loads/Load.cs
+++ b/GSA_Adapter/Convert/ToGsa/Loads/Load.cs
@@ -66,9 +66,9 @@ namespace BH.Adapter.GSA
         /**** Fallback  Method                         ****/
         /***************************************************/
 
-        public static List<string> ToGsaString(this ILoad load, double[] unitFactors)
+        private static List<string> ToGsaString(this ILoad load, double[] unitFactors)
         {
-            Engine.Base.Compute.RecordError($"{load.GetType()} is not implemented for GSA_Toolkit.");
+            Engine.Base.Compute.RecordError($"Pushing load of type {load.GetType()} is not implemented for GSA_Toolkit.");
             return new List<string>();
         }
 

--- a/GSA_Adapter/Convert/ToGsa/Loads/NodeLoad.cs
+++ b/GSA_Adapter/Convert/ToGsa/Loads/NodeLoad.cs
@@ -36,15 +36,14 @@ namespace BH.Adapter.GSA
 
         public static List<string> ToGsaString(this IElementLoad<Node> nodeLoad, double[] unitFactors)
         {
-            string command;
-            List<string> forceStrings = new List<string>();
-            double factor;
+            double factor = nodeLoad.IFactor(unitFactors);
+            if (double.IsNaN(factor))
+                return new List<string>();
 
+            string command = nodeLoad.IForceTypeString(); ;
             Vector[] force = nodeLoad.ITranslationVector();
-            command = nodeLoad.IForceTypeString();
             Vector[] moment = nodeLoad.IRotationVector();
-            factor = nodeLoad.IFactor(unitFactors);
-
+            
             string name = nodeLoad.Name;
             string str;
             string appliedTo = nodeLoad.CreateIdListOrGroupName();
@@ -54,6 +53,7 @@ namespace BH.Adapter.GSA
 
             str = command + "," + name + "," + appliedTo + "," + caseNo + "," + axis;
 
+            List<string> forceStrings = new List<string>();
             VectorDataToString(str, force, ref forceStrings, factor, true, pos);
             VectorDataToString(str, moment, ref forceStrings, factor, false, pos);
 

--- a/GSA_Engine/Modify/SetAnalysisSettings.cs
+++ b/GSA_Engine/Modify/SetAnalysisSettings.cs
@@ -39,8 +39,9 @@ namespace BH.Engine.Adapters.GSA
         /**** Public Methods                            ****/
         /***************************************************/
 
-        [Description("Sets the analysis type and stage for a LoadCombination")]
+        [Description("Sets the analysis type and stage for a LoadCombination.")]
         [Input("loadcombination", "The load combination to set stage and analysis type for.")]
+        [Input("analysisType", "The type of analysis e.g. LinearStatic.")]
         [Input("stage", "The stage number for the combination to be run on.")]
         [Input("residualForce", "Allowed residual Force for convergence, only used for Non-linear analysis.")]
         [Input("residualMoment", "Allowed residual Moment for convergence, only used for Non-linear analysis.")]

--- a/GSA_Engine/Modify/SetGSAId.cs
+++ b/GSA_Engine/Modify/SetGSAId.cs
@@ -38,9 +38,9 @@ namespace BH.Engine.Adapters.GSA
         /**** Public Methods                            ****/
         /***************************************************/
         
-        public static void SetGSAId(this IBHoMObject BHoMObject, object id)
+        public static void SetGSAId(this IBHoMObject bhomObject, object id)
         {
-            BHoMObject.SetAdapterId(typeof(GSAId), id);
+            bhomObject.SetAdapterId(typeof(GSAId), id);
         }
         
         /***************************************************/

--- a/GSA_Engine/Query/GSAId.cs
+++ b/GSA_Engine/Query/GSAId.cs
@@ -40,9 +40,9 @@ namespace BH.Engine.Adapters.GSA
         /**** Public Methods                            ****/
         /***************************************************/
 
-        public static int GSAId(this IBHoMObject BHoMObject)
+        public static int GSAId(this IBHoMObject bhomObject)
         {
-            return BHoMObject.AdapterId<int>(typeof(GSAId));
+            return bhomObject.AdapterId<int>(typeof(GSAId));
         }
 
 


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #316 

 <!-- Add short description of what has been fixed -->


 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:u:/r/sites/BHoM/Installers/Scripts/Burohappold_BHoM_v7.1/Structures%20-%20Create%20read%20loads/BuroHappold_BHoM_v7.1.beta_Create%20read%20loads.gh?csf=1&web=1&e=c84a3u

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->
- Added fallback methods for `ILoad` and all `BHoMObjects` were a useful error message is returned when the object is not supported (as opposed to a C# exception.

 ### Additional comments
<!-- As required -->
I do not have GSA installed so would appreciate a quick test on this so I can make any changes as necessary.