### PR TITLE
Fix dummy elements push in GSA10

### DIFF
--- a/GSA_Adapter/Convert/ToGsa/Elements/Bar.cs
+++ b/GSA_Adapter/Convert/ToGsa/Elements/Bar.cs
@@ -51,8 +51,8 @@ namespace BH.Adapter.GSA
             string endIndex = bar.End.GSAId().ToString();
 
             string orientationAngle = (bar.OrientationAngle * 180 / Math.PI).ToString();
+            
             // TODO: Make sure that these are doing the correct thing. Release vs restraint corresponding to true vs false
-
             string RLS = "NO_RLS";
             if (type == "BEAM")
             {

--- a/GSA_Adapter/Convert/ToGsa/Elements/Bar.cs
+++ b/GSA_Adapter/Convert/ToGsa/Elements/Bar.cs
@@ -41,11 +41,6 @@ namespace BH.Adapter.GSA
 
         private static string ToGsaString(this Bar bar, string index)
         {
-#if GSA_10
-            string command = "EL.4";
-#else
-            string command = "EL.2";
-#endif
             string name = bar.TaggedName().ToGSACleanName();
             string type = GetElementTypeString(bar);
 
@@ -60,8 +55,11 @@ namespace BH.Adapter.GSA
             string startR = bar.Release != null ? CreateReleaseString(bar.Release.StartRelease) : "FFFFFF";
             string endR = bar.Release != null ? CreateReleaseString(bar.Release.EndRelease) : "FFFFFF";
             string dummy = CheckDummy(bar);
-
-            string str = command + ", " + index + "," + name + ", NO_RGB , " + type + " , " + sectionPropertyIndex + ", " + group + ", " + startIndex + ", " + endIndex + " , 0 ," + orientationAngle + ", RLS, " + startR + " , " + endR + ", NO_OFFSET," + dummy;
+#if GSA_10
+            string str = "EL.4" + ", " + index + "," + name + ", NO_RGB , " + type + " , " + sectionPropertyIndex + ", " + group + ", " + startIndex + ", " + endIndex + " , 0 ," + orientationAngle + ", RLS, " + startR + " , " + endR + ", NO_OFFSET," + ", NORMAL," + dummy;
+#else
+            string str = "EL.2" + ", " + index + "," + name + ", NO_RGB , " + type + " , " + sectionPropertyIndex + ", " + group + ", " + startIndex + ", " + endIndex + " , 0 ," + orientationAngle + ", RLS, " + startR + " , " + endR + ", NO_OFFSET," + dummy;
+#endif
             return str;
         }
 

--- a/GSA_Adapter/Convert/ToGsa/Elements/Bar.cs
+++ b/GSA_Adapter/Convert/ToGsa/Elements/Bar.cs
@@ -52,13 +52,20 @@ namespace BH.Adapter.GSA
 
             string orientationAngle = (bar.OrientationAngle * 180 / Math.PI).ToString();
             // TODO: Make sure that these are doing the correct thing. Release vs restraint corresponding to true vs false
-            string startR = bar.Release != null ? CreateReleaseString(bar.Release.StartRelease) : "FFFFFF";
-            string endR = bar.Release != null ? CreateReleaseString(bar.Release.EndRelease) : "FFFFFF";
+
+            string RLS = "NO_RLS";
+            if (type == "BEAM")
+            {
+                string startR = bar.Release != null ? CreateReleaseString(bar.Release.StartRelease) : "FFFFFF";
+                string endR = bar.Release != null ? CreateReleaseString(bar.Release.EndRelease) : "FFFFFF";
+                RLS = "RLS, " + startR + ", " + endR;
+            }
+
             string dummy = CheckDummy(bar);
 #if GSA_10
-            string str = "EL.4" + ", " + index + "," + name + ", NO_RGB , " + type + " , " + sectionPropertyIndex + ", " + group + ", " + startIndex + ", " + endIndex + " , 0 ," + orientationAngle + ", RLS, " + startR + " , " + endR + ", NO_OFFSET," + ", NORMAL," + dummy;
+            string str = "EL.4" + ", " + index + "," + name + ", NO_RGB , " + type + " , " + sectionPropertyIndex + ", " + group + ", " + startIndex + ", " + endIndex + " , 0 ," + orientationAngle + ", " + RLS + ", 0, 0, 0, 0, " + dummy;
 #else
-            string str = "EL.2" + ", " + index + "," + name + ", NO_RGB , " + type + " , " + sectionPropertyIndex + ", " + group + ", " + startIndex + ", " + endIndex + " , 0 ," + orientationAngle + ", RLS, " + startR + " , " + endR + ", NO_OFFSET," + dummy;
+            string str = "EL.2" + ", " + index + "," + name + ", NO_RGB , " + type + " , " + sectionPropertyIndex + ", " + group + ", " + startIndex + ", " + endIndex + " , 0 ," + orientationAngle + ", " + RLS + ", NO_OFFSET," + dummy;
 #endif
             return str;
         }


### PR DESCRIPTION
<!-- PLEASE ENSURE YOU REVIEW THE CONTENT OF EACH PR CAREFULLY, INCLUDING SUBSEQUENT COMMENTS BY YOURSELF OR OTHERS. -->
<!-- IN PARTICULAR PLEASE ENSURE THAT SENSITIVE OR INAPPROPRIATE INFORMATION IS NOT UPLOADED -->

 ### NOTE: Depends on 
<!-- Link to any additional PRs in other repos required for this PR to function -->
<!-- Delete if not required -->


 ### Issues addressed by this PR
<!-- Add reference(s) to issue(s) solved by this PR. Please use keyword Fixes/Closes as per https://help.github.com/articles/closing-issues-using-keywords/ -->

 Closes #358 

 <!-- Add short description of what has been fixed -->
Updated GSA string for push to GSA10 to correctly use dummy flag. 

As part of this had to update so that releases are only defined for beam elements, as the push wouldn't work otherwise. In GSA end releases for elements other than beams are dealt with by the member type itself so this change doesn't cause any issues.

 ### Test files
<!-- Link to test files to validate the proposed changes -->
https://burohappold.sharepoint.com/:f:/r/sites/BHoM/02_Current/12_Scripts/02_Pull%20Request/BHoM/GSA_Toolkit/%23359-DummyElementsInGSA10?csf=1&web=1&e=fV0V18

 ### Changelog
<!-- Text to go into changelog if applicable -->
<!-- Please see https://github.com/BHoM/documentation/wiki/changelog for guidelines -->


 ### Additional comments
<!-- As required -->
